### PR TITLE
Show full listing creation date in admin

### DIFF
--- a/src/components/Admin/AdminListings/AdminListingsTable/AdminListingTableRow.tsx
+++ b/src/components/Admin/AdminListings/AdminListingsTable/AdminListingTableRow.tsx
@@ -6,7 +6,7 @@ import BeeLink from 'shared/BeeLink';
 import Fab from 'shared/Fab';
 import { getListingStatus } from 'utils/listingStatus';
 import { Listing } from 'networking/listings';
-import { dateToYear } from 'utils/formatDate';
+import { formatSingleDate } from 'utils/formatDate';
 
 interface Props extends Listing {
   deleteListing: (id: string) => Promise<any>,
@@ -44,7 +44,7 @@ class AdminListingTableRow extends React.Component<Props> {
         </td>
         <td className="admin-table-row--item">
           <span>{getListingStatus(isInactive)}</span>
-          <span>Created: {dateToYear(createdAt)}</span>
+          <span>Created: {formatSingleDate(createdAt)}</span>
         </td>
         <td className="admin-table-row--item">
           <span className="edit-container">


### PR DESCRIPTION
## Description
Admin panel was just showing "Created: 2018" for listings; we'd like to show the date, too.

## How to Test
1. Go to `/admin/listings`
2. Verify that the status column displays month/day/year as "Created: MM/DD/YY"

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
