### PR TITLE
allow check-in (from) to be greater than check-out (to)

### DIFF
--- a/src/components/routes/Host/ListingForm/ListingForm.tsx
+++ b/src/components/routes/Host/ListingForm/ListingForm.tsx
@@ -68,10 +68,9 @@ const ListingFormSchema = Yup.object().shape({
   checkInTime: Yup.object().shape({
     from: Yup.string().oneOf(timeOptions),
     to: Yup.string().oneOf(timeOptions),
-  }).test('validCheckOutTime', '${path} interval is not valid', function () {
+  }).test('validCheckOutTime', 'Check-in (from) and Check-in (to) cannot be the same.', function () {
     const { from, to } = this.parent.checkInTime;
-    const fromIndex = timeOptions.indexOf(from);
-    return fromIndex !== -1 && timeOptions.indexOf(to) > fromIndex;
+    return from !== to;
   }),
   checkOutTime: Yup.string().oneOf(timeOptions),
   city: Yup.string().max(60, 'Too Long!'),


### PR DESCRIPTION
## Description
Why did you write this code?
https://beetoken.atlassian.net/browse/ENG-789

## How to Test
- [x] Visit `/host/listings/:id/checkin_details`
- [x] Click `Check-in (from) and Check-in (to)` and ensure `from` can be greater than `to` (i.e. from: 5:00pm and to: 2:00pm)
- [x] Click `Save & Exit` with no errors

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

