### PR TITLE
Integrate hotel listing properties into regular booking flow

### DIFF
--- a/src/components/routes/Listing/Listing/BookingRequestCard/BookingRequestCard.tsx
+++ b/src/components/routes/Listing/Listing/BookingRequestCard/BookingRequestCard.tsx
@@ -289,9 +289,9 @@ class BookingRequestCard extends React.Component<Props, State> {
       );
     }
 
-    return reservations.some(({ startDate, endDate }: Reservation) => {
+    return reservations.filter(({ startDate, endDate }: Reservation) => {
       return utcDay.isBetween(startDate, endDate, undefined, pickingEnd ? '(]' : '[)');
-    });
+    }).length >= totalQuantity;
   };
 }
 

--- a/src/components/routes/Listing/Listing/Listing.tsx
+++ b/src/components/routes/Listing/Listing/Listing.tsx
@@ -81,7 +81,7 @@ class Listing extends React.Component<RouterProps> {
                       pricePerNightEth={pricePerNightEth}
                       pricePerNightUsd={pricePerNightUsd}
                       reservations={reservations}
-                      totalQuantity={totalQuantity}
+                      totalQuantity={totalQuantity || 1}
                     />
                   );
                 }}


### PR DESCRIPTION
## Description
The booking flow for "auto-approve" bookings (hotel listings) is relatively untested and has fallen behind the nominal booking flow in terms of UX. In lieu of trying to get this up to speed, this changeset introduces concerns particular to "auto-approve" bookings (check-in date, check-out date, total quantity) into the Booking Request Card.

## How to Test
1. Create a new listing
    1. Choose a Home Type of "Hotel Room"
    2. Keep Auto-Approve set to *false*
    3. Set a check-in date, check-out date, and total quantity
2. Make a booking with that listing
    1. Verify that check-in/out dates from the listing form appear by default
    2. Verify that multiple bookings can be made on the property (up to total quantity)
3. Smoke-test bookings with other general listings (for regression)

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Assuming this approach works out, we may want to deprecate BuyNow and the `autoApprove` field generally. (If this approach *doesn't* work out, then future work is going to be updating the Buy Now flow to address existing UX issues)
