### PR TITLE
remove default capitalization for amenities

### DIFF
--- a/src/components/routes/Listing/Listing/Listing.container.ts
+++ b/src/components/routes/Listing/Listing/Listing.container.ts
@@ -121,7 +121,6 @@ const ListingContainerMobile = styled.div`
               margin-bottom: 8px;
               span {
                 padding-top: 2px;
-                text-transform: capitalize;
               }
             }
           }


### PR DESCRIPTION
## Description
Why did you write this code?
Remove caps so hosts can manually adjust their amenity capitalizations

## How to Test
- [ ] Visit listings/:id

Which devices did you test on?
- [z] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

