### PR TITLE
Use UTC for initial date picker state

### DIFF
--- a/src/components/routes/Listing/Listing/BookingRequestCard/BookingRequestCard.tsx
+++ b/src/components/routes/Listing/Listing/BookingRequestCard/BookingRequestCard.tsx
@@ -69,10 +69,10 @@ function getInitialState(props: Props): State {
   const { maxGuests } = props;
   const queryParams: QueryParams = parseQueryString(location.search);
   const { checkInDate, checkOutDate, numberOfGuests } = queryParams;
-  const startDate = checkInDate ? moment(checkInDate) :
-    props.checkInDate ? moment(props.checkInDate) : null;
-  const endDate = checkOutDate ? moment(checkOutDate) :
-    props.checkOutDate ? moment(props.checkOutDate) : null;
+  const startDate = checkInDate ? moment.utc(checkInDate) :
+    props.checkInDate ? moment.utc(props.checkInDate) : null;
+  const endDate = checkOutDate ? moment.utc(checkOutDate) :
+    props.checkOutDate ? moment.utc(props.checkOutDate) : null;
   const isDisabled: boolean = !(startDate && endDate);
   return {
     startDate,


### PR DESCRIPTION
## Description
@0xTail observed some incorrectly blocked-off dates after a test booking. In the database, found the associated booking had 08:00:00 in the time segment of check-in/check-out dates; we expect 00:00:00.

Found that this occurs when dates are provided at search time and then not modified by the date picker; the initial form state does not specify UTC when interpreting these parameters, and so they are treated in local system time.

Interpreting these parameters as UTC dates explicitly resolves the issue.

## How to Test
1. Search with values entered for check-in and check-out dates
2. Make a booking on some search result
3. Verify that check-in and check-out dates in database have a time of 00:00:00
4. Verify that booked dates are blocked out as expected on the listing page

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
