### PR TITLE
Keep listings inactive by default

### DIFF
--- a/src/components/routes/Host/ListingForm/ListingForm.tsx
+++ b/src/components/routes/Host/ListingForm/ListingForm.tsx
@@ -36,7 +36,7 @@ const defaultValues: FormValues = {
   // housing: '',
   houseRules: '',
   icalUrls: [],
-  isActive: true,
+  isActive: false,
   lat: 0,
   lng: 0,
   listingPicUrl: '',


### PR DESCRIPTION
## Description
Investigated incomplete listings made live on production, found that making a new listing and then immediately choosing to Save & Exit leaves an empty listing in a live state. Tracked this down to form defaults; `isActive` isn't shown in the listing form, but does have a default value.

Defaulted to false so that users will subsequently need to click Publish

## How to Test
1. Go to `/host/listings`
2. Click “Add New Listing”
3. Click “Save & Exit” right away
4. Verify that "Publish" is both disabled and unchecked

Which devices did you test on?
- [ ] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
We also want to relax validation on the admin form so that, should incomplete listings become active again through some means, admin can deactivate them directly.
