### PR TITLE
remove zendesk support from front page

### DIFF
--- a/src/components/App.routes.tsx
+++ b/src/components/App.routes.tsx
@@ -35,12 +35,6 @@ import AuthenticatedRoute from 'HOCs/AuthenticatedRoute';
 import { BannerConsumer, BannerConsumerProps } from 'HOCs/BannerProvider';
 import ZendeskWebWidgetWrapper from 'HOCs/ZendeskWebWidgetWrapper';
 
-const HomeWithZendesk = () => (
-  <ZendeskWebWidgetWrapper>
-    <Home />
-  </ZendeskWebWidgetWrapper>
-);
-
 const HostWithZendesk = (props: RouterProps) => (
   <ZendeskWebWidgetWrapper>
     <Host {...props} />
@@ -83,7 +77,7 @@ const AppRoutes = () => (
             <AuthenticatedRoute path="/trips/:id/receipt" component={TripsReceipt} />
             <AuthenticatedRoute path="/trips" component={Trips} />
             <Route path="/markets" component={Markets} />
-            <Route exact path="/" component={HomeWithZendesk} />
+            <Route exact path="/" component={Home} />
             <Route component={NotFound} />
           </Switch>
         </AppContainer>


### PR DESCRIPTION
## Description
This widget kills conversions. Remove it from front page.

## How to Test
- [ ] Visit /
- [ ] See no zendesk support widget
