### PR TITLE
kevin/ENG-850

### DIFF
--- a/src/components/routes/Account/StripeExpress/StripeExpressComplete.tsx
+++ b/src/components/routes/Account/StripeExpress/StripeExpressComplete.tsx
@@ -74,7 +74,7 @@ export class StripeExpressComplete extends React.Component<RouterProps> {
               For any Stripe account changes or updates please follow the email confirmation link to access your Stripe account.
             </p>
 
-            <BeeLink to="/">
+            <BeeLink to="/host/listings">
               <Button>Finished!</Button>
             </BeeLink>
           </>

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -98,11 +98,13 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
   }
 
   componentDidMount() {
-    this.props.createStripeLoginLink()
-      .then((stripeLoginLink: any) => {
-        this.setState({ stripeLoginLink: stripeLoginLink.data.createStripeLoginLink.url })
-      })
-      .catch(error => console.error(error));
+    if (this.props.stripeAccountDashboardLink) {
+      this.props.createStripeLoginLink()
+        .then((stripeLoginLink: any) => {
+          this.setState({ stripeLoginLink: stripeLoginLink.data.createStripeLoginLink.url })
+        })
+        .catch(error => console.error(error));
+    }
   }
 
   render() {


### PR DESCRIPTION
## Description
Why did you write this code?
fix(host-portal): fix stripe login link error and stripe-express complete route to host/listings
## How to Test
- [x] Create new account
- [x] Visit /host/payments (no errors should show in console)
- [x] Create Stripe Express account, should route you to thank you page with no errors
- [ ] Clicking 'Finished!' should route you to /host/listings
- [ ] Going to /host/payments should show no errors, and Stripe CTA should now say 'Go to Stripe dashboard' and route you to your Stripe dashboard
