### PR TITLE
add listing link

### DIFF
--- a/src/components/Admin/AdminUsers/AdminUsersTable/AdminUsersTableRow.tsx
+++ b/src/components/Admin/AdminUsers/AdminUsersTable/AdminUsersTableRow.tsx
@@ -15,7 +15,7 @@ interface Props extends User {
 }
 
 const AdminUsersTableRow = (props: Props) => {
-  const { completedVerification, onDeleteUser, id, email, firstName, lastName, stripeAccountDashboardLink, walletAddress } = props;
+  const { completedVerification, onDeleteUser, id, email, firstName, lastName, stripeAccountDashboardLink, walletAddress, listingCount } = props;
   return (
     <tr className="admin-table-row-container">
       <td className="admin-table-row--item">
@@ -38,6 +38,7 @@ const AdminUsersTableRow = (props: Props) => {
       <td className="admin-table-row--item">
         <span>{completedVerification ? 'Verified' : 'Not Verified'}</span>
         <span><BeeLink href={`https://app.autopilothq.com/#contacts/list/all/search/${email}/`} target="_blank">User Activity Autopilot</BeeLink></span>
+        {!!listingCount && listingCount > 0 && <span><BeeLink to={`/admin/listings?userId=${id}`}>See {listingCount} listings</BeeLink></span> }
       </td>
       <td className="admin-table-row--item">
         <span className="edit-container">

--- a/src/networking/users.ts
+++ b/src/networking/users.ts
@@ -22,6 +22,7 @@ export interface User {
   stripeAccountDashboardLink: string | null;
   supportEmail: string | null;
   walletAddress: string | null;
+  listingCount: number | null;
 }
 
 export interface CreateUser {
@@ -51,6 +52,7 @@ export const GET_ACCOUNT_PAGE = gql`
       profilePicUrl
       stripeAccountDashboardLink
       walletAddress
+      listingCount
     }
 
     creditBalance {
@@ -67,12 +69,12 @@ export const GET_USER = gql`
       email
       firstName
       id
-      # greeting # Greeting column not in DB yet
       lastName
       phoneNumber
       profilePicUrl
       stripeAccountDashboardLink
       walletAddress
+      listingCount
     }
   }
 `;
@@ -89,6 +91,7 @@ export const GET_USER_BY_ID = gql`
       profilePicUrl
       stripeAccountDashboardLink
       walletAddress
+      listingCount
     }
   }
 `;
@@ -105,6 +108,7 @@ export const GET_ALL_USERS = gql`
       profilePicUrl
       stripeAccountDashboardLink
       walletAddress
+      listingCount
     }
   }
 `;
@@ -138,6 +142,7 @@ export const SEARCH_USERS = gql`
         lastName
         stripeAccountDashboardLink
         walletAddress
+        listingCount
       }
       count
     }
@@ -155,6 +160,7 @@ export const SEARCH_HOSTS = gql`
         lastName
         stripeAccountDashboardLink
         walletAddress
+        listingCount
       }
       count
     }
@@ -246,7 +252,6 @@ export const UPDATE_USER = gql`
       about
       email
       firstName
-      # greeting # greeting column not in DB yet
       lastName
       phoneNumber
       profilePicUrl


### PR DESCRIPTION
## Description
It'll be helpful to quickly get to a user's listings in the admin section

## How to Test
- [ ] Visit /admin/users
- [ ] Scroll until you see a "See XX Listings" in the row
- [ ] Clicking that goes to the row

Needs https://github.com/thebeetoken/beenest-backend/pull/639 to work

## Learnings
Can we use GraphQL fragments here to reduce re specifying all the user fields?

