### PR TITLE
Use lat/lng bounds when searching

### DIFF
--- a/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
+++ b/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
@@ -54,10 +54,12 @@ const ListingQuery = () => {
     numberOfGuests: numberOfGuests ? parseInt(numberOfGuests) : 1,
     locationQuery: locationQuery || '',
     ...(areBoundsValid && {
-      east: parseFloat(bounds.east),
-      north: parseFloat(bounds.north),
-      south: parseFloat(bounds.south),
-      west: parseFloat(bounds.west),
+      bounds: {
+        east: parseFloat(bounds.east),
+        north: parseFloat(bounds.north),
+        south: parseFloat(bounds.south),
+        west: parseFloat(bounds.west),
+      }
     }),
     ...(areCoordinatesValid && {
       coordinates: {

--- a/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
+++ b/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
@@ -53,7 +53,7 @@ const ListingQuery = () => {
     checkOutDate: checkOutDate && isValid(new Date(checkOutDate)) ? checkOutDate : '',
     numberOfGuests: numberOfGuests ? parseInt(numberOfGuests) : 1,
     locationQuery: locationQuery || '',
-    ...(areBoundsValid && {
+    ...(areBoundsValid && !!bounds && {
       bounds: {
         east: parseFloat(bounds.east),
         north: parseFloat(bounds.north),

--- a/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
+++ b/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
@@ -27,6 +27,12 @@ const ListingsResult = () => (
 );
 
 interface QueryParams {
+  bounds?: {
+    east: string;
+    north: string;
+    south: string;
+    west: string;
+  };
   checkInDate?: string;
   checkOutDate?: string;
   coordinates?: {
@@ -39,13 +45,20 @@ interface QueryParams {
 
 const ListingQuery = () => {
   const queryParams: QueryParams = parseQueryString(location.search);
-  const { checkInDate, checkOutDate, coordinates, numberOfGuests, locationQuery } = queryParams;
+  const { bounds, checkInDate, checkOutDate, coordinates, numberOfGuests, locationQuery } = queryParams;
+  const areBoundsValid = bounds && bounds.east && bounds.north && bounds.south && bounds.west;
   const areCoordinatesValid = coordinates && coordinates.lat && coordinates.lng;
   const input = {
     checkInDate: checkInDate && isValid(new Date(checkInDate)) ? checkInDate : '',
     checkOutDate: checkOutDate && isValid(new Date(checkOutDate)) ? checkOutDate : '',
     numberOfGuests: numberOfGuests ? parseInt(numberOfGuests) : 1,
     locationQuery: locationQuery || '',
+    ...(areBoundsValid && {
+      east: parseFloat(bounds.east),
+      north: parseFloat(bounds.north),
+      south: parseFloat(bounds.south),
+      west: parseFloat(bounds.west),
+    }),
     ...(areCoordinatesValid && {
       coordinates: {
         lat: coordinates && coordinates.lat ? parseFloat(coordinates.lat) : 0,

--- a/src/components/shared/SearchBar/SearchBar.tsx
+++ b/src/components/shared/SearchBar/SearchBar.tsx
@@ -29,7 +29,15 @@ interface LatLng {
   lng: number,
 }
 
+interface LatLngBounds {
+  east: number;
+  north: number;
+  south: number;
+  west: number;
+}
+
 interface State {
+  bounds: LatLngBounds | null;
   coordinates: LatLng | null;
   checkInDate: moment.Moment | null;
   checkOutDate: moment.Moment | null;
@@ -42,6 +50,7 @@ function getInitialState({ location }: RouterProps): State {
   const queryParams: QueryParams = parseQueryString(location.search);
   const { checkInDate, checkOutDate, numberOfGuests, locationQuery } = queryParams;
   return {
+    bounds: null,
     coordinates: null,
     locationQuery,
     focusedInput: null,
@@ -154,12 +163,12 @@ class SearchBar extends React.Component<RouterProps, State> {
   
   handlePlaceChange = (place: google.maps.places.PlaceResult) => {
     if (!place.geometry) return;
-    
     this.setState({
       coordinates: {
         lat: place.geometry.location.lat(),
         lng: place.geometry.location.lng(),
-      }
+      },
+      bounds: place.geometry.viewport.toJSON()
     })
   }
 

--- a/src/components/shared/SearchBar/SearchBar.tsx
+++ b/src/components/shared/SearchBar/SearchBar.tsx
@@ -183,13 +183,14 @@ class SearchBar extends React.Component<RouterProps, State> {
 
   handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    const { coordinates, checkInDate, checkOutDate, numberOfGuests } = this.state;
+    const { bounds, coordinates, checkInDate, checkOutDate, numberOfGuests } = this.state;
     const locationQuery = this.inputRef.current ? this.inputRef.current.value : '';
     return this.props.history.push({
       pathname: '/listings',
       search: stringifyQueryString({
         locationQuery,
         utm_term: locationQuery,
+        ...(bounds && { bounds }),
         ...(coordinates && { coordinates }),
         ...(numberOfGuests && { numberOfGuests }),
         ...(checkInDate && {


### PR DESCRIPTION
## Description
Get the lat/lng boundary associated with a search term from Google's APIs, and pass that information along to the back-end so that queries for larger regions (e.g. "Hawaii") don't fail due to the search area chosen by the backend.

Note that this depends on thebeetoken/beenest-backend#649 and should be merged after that PR has been merged (and not before)

## How to Test
1. Search "Hawaii"
2. Verify that results appear

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
