### PR TITLE
Don't override currency when currency is undefined

### DIFF
--- a/src/components/routes/Booking/BookingPayment/BookingPayment.tsx
+++ b/src/components/routes/Booking/BookingPayment/BookingPayment.tsx
@@ -48,7 +48,7 @@ const BookingPayment = ({ history, match }: RouterProps) => (
       return (
         <Async promise={pricePromise} then={price => {
           // The 1.01 multiplier below accounts for fluctuating exchange rates etc.
-          const fromBee = (!!price && currency !== booking.currency) ?
+          const fromBee = (!!price && !!currency && currency !== booking.currency) ?
             ((value: number) => value * price * 1.01 / booking.guestTotalAmount) :
             undefined;
           return (


### PR DESCRIPTION
## Description
Some client-side currency conversions were added in support of DAI, as ERC-20 conversion rates are not known until run-time. A logic error here caused a no-op currency conversion (on BEE) to be applied when USD was selected, resulting in USD prices being shown at BEE magnitudes.

## How to Test
1. Make a new booking
2. Select "Credit Card" from payment options
3. Verify that price remains the same when continuing on to `/payment`

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
This bug relates to [known issues](https://github.com/thebeetoken/beenest-web/pull/60#issuecomment-455325537) with the complexity of inter-component communication around currency which make correctness more difficult to reason about. Filed ENG-892 to capture that in the issue tracker but have not scheduled.

## Learnings
Regression test all the time