### PR TITLE
Restrict contract cancellation to times when guest has paid

### DIFF
--- a/src/components/routes/Trips/Trips.tsx
+++ b/src/components/routes/Trips/Trips.tsx
@@ -173,9 +173,9 @@ export default compose(
   graphql(GUEST_CANCEL_BOOKING, {
     props: ({ mutate }: any) => ({
       cancelBooking: async (booking: Booking) => {
-        const { id, currency, checkInDate } = booking;
+        const { id, currency, checkInDate, status } = booking;
         const days = differenceInDays(checkInDate, Date.now());
-        if (currency === Currency.BEE && days >= 7) {
+        if (currency === Currency.BEE && days >= 7 && status === 'guest_paid') {
           const web3 = loadWeb3();
           await cancel(web3.eth, id);
         }


### PR DESCRIPTION
## Description
The "Cancel" button on the "Trips" page was causing MetaMask to show in cases when the guest had not actually been charged yet. This restricts the contract call to cases where the guest has actually paid.

## How to Test
1. Make a new BEE booking
    1. Note that this must be >1wk in the future for the original bug to be reproducible
2. Do *not* accept as a host
3. Go to Trips
4. Cancel
5. Verify that MetaMask does *not* appear

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

