### PR TITLE
Select USD as payment option by default

### DIFF
--- a/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -26,7 +26,7 @@ interface State {
 class SelectPaymentOption extends React.Component<Props> {
   readonly state: State = {
     conversionRateFromBee: 0,
-    currency: undefined,
+    currency: Currency.USD,
     errorPricingToken: false
   };
 


### PR DESCRIPTION
## Description
Suggested by marketing at All Hands, show Credit Card as the default payment option instead of requiring the user to choose.

## How to Test
1. Find a listing
2. Request to book
3. Verify that "Credit Card" is shown in the "Select Method of Payment" dropdown 

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
When everybody's paying with BEE we can change this default again 🐝

## Learnings
Multi-user testing finds issues that end-internal testing does not.

