### PR TITLE
Add BTC to payment options

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -14,6 +14,7 @@ module.exports = {
     BEETOKEN_ADDRESS: '0x7fffac23d59d287560dfeca7680b5393426cf503',
     BEETOKEN_PAYMENT_ADDRESS: '0x3a5ad6a52582c18dad0a7d300f3a2beac3e762e4',
     ETH_PAYMENT_ADDRESS: '0x8a436f1b5f6d30ddd9c05d1fd47fdb937366ee1a',
+    BTC_PAYMENT_ADDRESS: 'btc-payment-address-goes-here',
     FIREBASE_CONFIG: {
       apiKey: 'AIzaSyBVVBElrARlNDNLeTAHYuD6dvvAIXdU93E',
       authDomain: 'the-bee-token-firebae-dev.firebaseapp.com',
@@ -37,6 +38,7 @@ module.exports = {
     BEETOKEN_ADDRESS: '0x7fffac23d59d287560dfeca7680b5393426cf503',
     BEETOKEN_PAYMENT_ADDRESS: '0x3a5ad6a52582c18dad0a7d300f3a2beac3e762e4',
     ETH_PAYMENT_ADDRESS: '0x8a436f1b5f6d30ddd9c05d1fd47fdb937366ee1a',
+    BTC_PAYMENT_ADDRESS: 'btc-payment-address-goes-here',
     FIREBASE_CONFIG: {
       apiKey: 'AIzaSyBVVBElrARlNDNLeTAHYuD6dvvAIXdU93E',
       authDomain: 'the-bee-token-firebae-dev.firebaseapp.com',
@@ -60,6 +62,7 @@ module.exports = {
     BEETOKEN_ADDRESS: '0x4D8fc1453a0F359e99c9675954e656D80d996FbF',
     BEETOKEN_PAYMENT_ADDRESS: '0xb3C348c4a6D95fee050bF8A770fC91EC60aa4ab2',
     ETH_PAYMENT_ADDRESS: '0x8a436f1b5f6d30ddd9c05d1fd47fdb937366ee1a',
+    BTC_PAYMENT_ADDRESS: 'btc-payment-address-goes-here',
     FIREBASE_CONFIG: {
       apiKey: 'AIzaSyAv9jUUQcob4SjtUIMOylkImD8UogfaqNo',
       authDomain: 'beetoken-staging.firebaseapp.com',
@@ -83,6 +86,7 @@ module.exports = {
     BEETOKEN_ADDRESS: '0x4D8fc1453a0F359e99c9675954e656D80d996FbF',
     BEETOKEN_PAYMENT_ADDRESS: '0xb3C348c4a6D95fee050bF8A770fC91EC60aa4ab2',
     ETH_PAYMENT_ADDRESS: '',
+    BTC_PAYMENT_ADDRESS: 'btc-payment-address-goes-here',
     FIREBASE_CONFIG: {
       apiKey: 'AIzaSyDS9QPfvghy3gX0pLIayXLnpOCTV2rJwe0',
       authDomain: 'beetoken-prod.firebaseapp.com',

--- a/config/settings.js
+++ b/config/settings.js
@@ -14,7 +14,7 @@ module.exports = {
     BEETOKEN_ADDRESS: '0x7fffac23d59d287560dfeca7680b5393426cf503',
     BEETOKEN_PAYMENT_ADDRESS: '0x3a5ad6a52582c18dad0a7d300f3a2beac3e762e4',
     ETH_PAYMENT_ADDRESS: '0x8a436f1b5f6d30ddd9c05d1fd47fdb937366ee1a',
-    BTC_PAYMENT_ADDRESS: 'btc-payment-address-goes-here',
+    BTC_PAYMENT_ADDRESS: '3AxdWezuK1yLbZni56y7EzxUS7rjJnPL6U',
     FIREBASE_CONFIG: {
       apiKey: 'AIzaSyBVVBElrARlNDNLeTAHYuD6dvvAIXdU93E',
       authDomain: 'the-bee-token-firebae-dev.firebaseapp.com',
@@ -38,7 +38,7 @@ module.exports = {
     BEETOKEN_ADDRESS: '0x7fffac23d59d287560dfeca7680b5393426cf503',
     BEETOKEN_PAYMENT_ADDRESS: '0x3a5ad6a52582c18dad0a7d300f3a2beac3e762e4',
     ETH_PAYMENT_ADDRESS: '0x8a436f1b5f6d30ddd9c05d1fd47fdb937366ee1a',
-    BTC_PAYMENT_ADDRESS: 'btc-payment-address-goes-here',
+    BTC_PAYMENT_ADDRESS: '3AxdWezuK1yLbZni56y7EzxUS7rjJnPL6U',
     FIREBASE_CONFIG: {
       apiKey: 'AIzaSyBVVBElrARlNDNLeTAHYuD6dvvAIXdU93E',
       authDomain: 'the-bee-token-firebae-dev.firebaseapp.com',
@@ -62,7 +62,7 @@ module.exports = {
     BEETOKEN_ADDRESS: '0x4D8fc1453a0F359e99c9675954e656D80d996FbF',
     BEETOKEN_PAYMENT_ADDRESS: '0xb3C348c4a6D95fee050bF8A770fC91EC60aa4ab2',
     ETH_PAYMENT_ADDRESS: '0x8a436f1b5f6d30ddd9c05d1fd47fdb937366ee1a',
-    BTC_PAYMENT_ADDRESS: 'btc-payment-address-goes-here',
+    BTC_PAYMENT_ADDRESS: '3AxdWezuK1yLbZni56y7EzxUS7rjJnPL6U',
     FIREBASE_CONFIG: {
       apiKey: 'AIzaSyAv9jUUQcob4SjtUIMOylkImD8UogfaqNo',
       authDomain: 'beetoken-staging.firebaseapp.com',
@@ -86,7 +86,7 @@ module.exports = {
     BEETOKEN_ADDRESS: '0x4D8fc1453a0F359e99c9675954e656D80d996FbF',
     BEETOKEN_PAYMENT_ADDRESS: '0xb3C348c4a6D95fee050bF8A770fC91EC60aa4ab2',
     ETH_PAYMENT_ADDRESS: '',
-    BTC_PAYMENT_ADDRESS: 'btc-payment-address-goes-here',
+    BTC_PAYMENT_ADDRESS: '3AxdWezuK1yLbZni56y7EzxUS7rjJnPL6U',
     FIREBASE_CONFIG: {
       apiKey: 'AIzaSyDS9QPfvghy3gX0pLIayXLnpOCTV2rJwe0',
       authDomain: 'beetoken-prod.firebaseapp.com',

--- a/src/components/routes/Booking/BookingOptions/BookingOptionsBTC/BookingOptionsBTC.tsx
+++ b/src/components/routes/Booking/BookingOptions/BookingOptionsBTC/BookingOptionsBTC.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { withRouter } from 'react-router-dom';
+
+import { Booking, Currency } from 'networking/bookings';
+
+import BookingOptionsUSDContainer from '../BookingOptionsUSD/BookingOptionsUSD.container';
+import SelectPaymentButton from '../SelectPaymentButton';
+import Button from 'shared/Button';
+
+interface Props extends RouterProps {
+  booking: Booking;
+}
+
+const BookingOptionsBTC = ({ booking, history }: Props) => (
+  <BookingOptionsUSDContainer>
+    <div className="booking-options-button-container">
+      <Button
+        className="back-button"
+        background="light"
+        onClick={() => history.push(`/listings/${booking.listingId}`)}
+      >
+        Back
+      </Button>
+      <SelectPaymentButton
+        booking={booking}
+        currency={Currency.BTC}
+        onSuccess={() => history.push(`/bookings/${booking.id}/payment`)}
+      />
+    </div>
+  </BookingOptionsUSDContainer>
+);
+
+export default withRouter(BookingOptionsBTC);

--- a/src/components/routes/Booking/BookingOptions/BookingOptionsBTC/index.ts
+++ b/src/components/routes/Booking/BookingOptions/BookingOptionsBTC/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BookingOptionsBTC';

--- a/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -35,6 +35,7 @@ class SelectPaymentOption extends React.Component<Props> {
     const { booking } = this.props;
     const showBee = !!booking.host.walletAddress;
     const showEth = !!booking.host.walletAddress && APP_ENV !== AppEnv.PRODUCTION;
+    const showBtc = booking.priceQuotes.some(({ currency }) => currency === Currency.BTC);
     // The 1.01 multiplier below accounts for fluctuating exchange rates etc.
     const fromBee = errorPricingToken ?
       (() => '--.--' ) :
@@ -58,6 +59,7 @@ class SelectPaymentOption extends React.Component<Props> {
                 {showBee && <option value={Currency.BEE}>BEE</option>}
                 {showBee && <option value={Currency.DAI}>DAI</option>}
                 {showEth && <option value={Currency.ETH}>ETH</option>}
+                {showBtc && <option value={Currency.BTC}>BTC</option>}
                 <option value={Currency.USD}>Credit Card</option>
               </select>
               <Svg className="suffix" src="utils/carat-down" />

--- a/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -4,6 +4,7 @@ import { Booking, Currency } from 'networking/bookings';
 
 import SelectPaymentOptionContainer from './SelectPaymentOption.container';
 import BookingOptionsUSD from '../BookingOptionsUSD';
+import BookingOptionsBTC from '../BookingOptionsBTC';
 import BookingQuote from '../../BookingQuote';
 import { AppConsumer, AppConsumerProps, ScreenType } from 'components/App.context';
 import BookingOptionsCrypto from '../BookingOptionsCrypto';
@@ -106,6 +107,8 @@ function currencyOptions(currency: string | undefined, booking: Booking, fromBee
       return <BookingOptionsCrypto booking={booking} currency={currency} fromBee={fromBee} />;
     case Currency.USD:
       return <BookingOptionsUSD booking={booking} />;
+    case Currency.BTC:
+      return <BookingOptionsBTC booking={booking} />;
     default:
       return null;
   }

--- a/src/components/routes/Booking/BookingPayment/BookingPaymentButton.tsx
+++ b/src/components/routes/Booking/BookingPayment/BookingPaymentButton.tsx
@@ -33,7 +33,7 @@ class BookingPaymentButton extends React.Component<Props, State> {
   render() {
     const { isSubmitting } = this.state;
     const { booking, fromBee } = this.props;
-    if (booking.currency === Currency.USD) {
+    if (booking.currency === Currency.USD || booking.currency === Currency.BTC) {
       // We do this onclick pattern because if bound, the guestWalletAddress will be an event handler
       return (
         <>
@@ -43,7 +43,7 @@ class BookingPaymentButton extends React.Component<Props, State> {
                 <GridLoading height={105} width={105} />
                 <div className="processing-card">
                   <h2>Processing payment...</h2>
-                  <p>Crypto payments may take up to 30 seconds to complete transaction.</p>
+                  <p>Payments may take up to 30 seconds to complete transaction.</p>
                 </div>
               </BookingPaymentLoadingContainer>
             </Portal>
@@ -122,7 +122,7 @@ async function getCryptoParams(
   currency?: Currency | string,
   fromBee?: (value: number) => number
 ): Promise<CryptoParams | undefined> {
-  if (booking.currency === Currency.USD || !guestWalletAddress) {
+  if (booking.currency === Currency.USD || booking.currency === Currency.BTC || !guestWalletAddress) {
     return undefined;
   }
   const web3 = loadWeb3();

--- a/src/components/routes/Booking/BookingReceipt/BookingReceipt.tsx
+++ b/src/components/routes/Booking/BookingReceipt/BookingReceipt.tsx
@@ -44,7 +44,7 @@ const BookingReceipt = ({ match }: RouterProps) => (
                 <Confirmation {...booking} />
               </div>
               <div className="total-paid-container">
-                <h2>Total Paid:</h2>
+                <h2>Total {currency !== Currency.BTC ? 'Paid' : 'Due'}:</h2>
                 <span>{totalPaid}</span>
               </div>
               <div className="payment-option-container">

--- a/src/components/routes/Booking/BookingReceipt/BookingReceipt.tsx
+++ b/src/components/routes/Booking/BookingReceipt/BookingReceipt.tsx
@@ -129,6 +129,8 @@ const Confirmation = ({ currency, id, guestTxHash }: Booking) => (
             <div className="disclaimer">
               Payment is due at the address above. This booking is not valid until paid.
               You will be notified via email within 24 hours once your host confirms your booking.
+              If the booking is declined, the paid amount will be returned to the address you used
+              to pay.
             </div>
           </>
         );

--- a/src/components/routes/Booking/BookingReceipt/BookingReceipt.tsx
+++ b/src/components/routes/Booking/BookingReceipt/BookingReceipt.tsx
@@ -28,14 +28,19 @@ const BookingReceipt = ({ match }: RouterProps) => (
       }
       const { currency, guestTotalAmount, guestWalletAddress, guestTxHash } = booking;
       const totalPaid = `${numberToLocaleString(guestTotalAmount, currency)} ${currency}`;
-      const isCrypto = currency !== Currency.USD;
+      const isCrypto = currency !== Currency.USD && currency !== Currency.BTC;
       return (
         <BookingReceiptContainer>
           <BookingNavBar />
           <div className="booking-receipt-wrapper">
             <div className="booking-receipt-body">
               <div className="confirmation-container">
-                <h2>Payment confirmed. Your request has been sent to host for approval.</h2>
+                {currency !== Currency.BTC &&
+                  <h2>Payment confirmed. Your request has been sent to host for approval.</h2>
+                }
+                {currency === Currency.BTC &&
+                  <h2>Your request has been sent to host for approval.</h2>
+                }
                 <Confirmation {...booking} />
               </div>
               <div className="total-paid-container">
@@ -108,6 +113,20 @@ const Confirmation = ({ currency, id, guestTxHash }: Booking) => (
               You will be notified via email within 24 hours once your host confirms your booking. In the instance where
               the host fails to confirm, we will refund your payment in full. A full transaction receipt will be sent to
               your email.
+            </div>
+          </>
+        );
+      }
+      if (currency === Currency.BTC) {
+        return (
+          <>
+            <div className="usd-confirmation-container">
+              <h3>Payment Address</h3>
+              <span>{'abcXFADSGADSkmn120321BTC!!'}</span>
+            </div>
+            <div className="disclaimer">
+              Payment is due at the address above. This booking is not valid until paid.
+              You will be notified via email within 24 hours once your host confirms your booking.
             </div>
           </>
         );

--- a/src/components/routes/Booking/BookingReceipt/BookingReceipt.tsx
+++ b/src/components/routes/Booking/BookingReceipt/BookingReceipt.tsx
@@ -3,7 +3,7 @@ import { Query } from 'react-apollo';
 import { Link, Redirect } from 'react-router-dom';
 
 import { GET_BOOKING_RECEIPT, Booking, Currency } from 'networking/bookings';
-import { APP_ENV, AppEnv } from 'configs/settings';
+import { APP_ENV, AppEnv, SETTINGS } from 'configs/settings';
 
 import BookingReceiptContainer from './BookingReceipt.container';
 import BookingNavBar from '../BookingNavBar';
@@ -11,6 +11,8 @@ import BookingReceiptBar from './BookingReceiptBar';
 import Button from 'shared/Button';
 import { numberToLocaleString } from 'utils/numberToLocaleString';
 import { AppConsumer, AppConsumerProps, ScreenType } from 'components/App.context';
+
+const { BTC_PAYMENT_ADDRESS } = SETTINGS;
 
 const BookingReceipt = ({ match }: RouterProps) => (
   <Query query={GET_BOOKING_RECEIPT} variables={{ id: match.params.id }}>
@@ -122,7 +124,7 @@ const Confirmation = ({ currency, id, guestTxHash }: Booking) => (
           <>
             <div className="usd-confirmation-container">
               <h3>Payment Address</h3>
-              <span>{'abcXFADSGADSkmn120321BTC!!'}</span>
+              <span>{BTC_PAYMENT_ADDRESS}</span>
             </div>
             <div className="disclaimer">
               Payment is due at the address above. This booking is not valid until paid.

--- a/src/configs/settings.ts
+++ b/src/configs/settings.ts
@@ -23,6 +23,7 @@ interface Setting {
   BEETOKEN_ADDRESS: string;
   BEETOKEN_PAYMENT_ADDRESS: string;
   ETH_PAYMENT_ADDRESS: string;
+  BTC_PAYMENT_ADDRESS: string;
   FACEBOOK_APP_ID: string;
   FIREBASE_CONFIG: {
     apiKey: string;

--- a/src/networking/bookings.ts
+++ b/src/networking/bookings.ts
@@ -47,6 +47,7 @@ export enum BookingStatus {
 
 export enum Currency {
   BEE = 'BEE',
+  BTC = 'BTC',
   DAI = 'DAI',
   ETH = 'ETH',
   USD = 'USD',

--- a/src/utils/numberToLocaleString.ts
+++ b/src/utils/numberToLocaleString.ts
@@ -1,6 +1,6 @@
 import { Currency } from 'networking/bookings';
 
-const CURRENCY_DIGITS = {
+const CURRENCY_DIGITS: {[index: string]: number} = {
   [Currency.BEE]: 0,
   [Currency.BTC]: 6,
   [Currency.ETH]: 4,
@@ -17,7 +17,7 @@ export function numberToLocaleString(value: number | string, currency: Currency 
     return '';
   }
 
-  const digits = CURRENCY_DIGITS.hasOwnProperty(currency) ?
+  const digits = !!currency && CURRENCY_DIGITS.hasOwnProperty(currency) ?
     CURRENCY_DIGITS[currency] : DEFAULT_DIGITS;
 
   return value.toLocaleString(undefined, {

--- a/src/utils/numberToLocaleString.ts
+++ b/src/utils/numberToLocaleString.ts
@@ -2,6 +2,7 @@ import { Currency } from 'networking/bookings';
 
 const CURRENCY_DIGITS = {
   [Currency.BEE]: 0,
+  [Currency.BTC]: 6,
   [Currency.ETH]: 4,
   [Currency.USD]: 2,
 };

--- a/src/utils/numberToLocaleString.ts
+++ b/src/utils/numberToLocaleString.ts
@@ -1,5 +1,12 @@
 import { Currency } from 'networking/bookings';
 
+const CURRENCY_DIGITS = {
+  [Currency.BEE]: 0,
+  [Currency.ETH]: 4,
+  [Currency.USD]: 2,
+};
+const DEFAULT_DIGITS = 2;
+
 export function numberToLocaleString(value: number | string, currency: Currency | null = Currency.USD): string {
   if (typeof value !== 'number') {
     return value;
@@ -9,34 +16,11 @@ export function numberToLocaleString(value: number | string, currency: Currency 
     return '';
   }
 
+  const digits = CURRENCY_DIGITS.hasOwnProperty(currency) ?
+    CURRENCY_DIGITS[currency] : DEFAULT_DIGITS;
+
   return value.toLocaleString(undefined, {
-    minimumFractionDigits: getMinimumFractionDigits(currency),
-    maximumFractionDigits: getMaximumFractionDigits(currency),
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
   });
-}
-
-function getMinimumFractionDigits(currency: Currency | null): number {
-  switch (currency) {
-    case Currency.BEE:
-      return 0;
-    case Currency.ETH:
-      return 4;
-    case Currency.USD:
-      return 2;
-    default:
-      return 2;
-  }
-}
-
-function getMaximumFractionDigits(currency: Currency | null): number {
-  switch (currency) {
-    case Currency.BEE:
-      return 0;
-    case Currency.ETH:
-      return 4;
-    case Currency.USD:
-      return 2;
-    default:
-      return 2;
-  }
 }


### PR DESCRIPTION
## Description
Adds BTC as a payment option to increase reach to BTC hodlers

## How to Test
1. Find a listing, start a booking
2. Select BTC as payment option
3. Click forward through "Submit Payment"
4. Expect to see a Bitcoin wallet address with the amount due and instructions for payment

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
This implementation will be a simple address that guests can send BTC to. Will we want to automate this? We'll see!

## Learnings
Bees communicate the location of interesting food sources by flying in figure eights and wiggling their butts, and so do I.