### PR TITLE
Only wire in Autocomplete when google loads

### DIFF
--- a/src/components/shared/GoogleAutoComplete/GoogleAutoComplete.tsx
+++ b/src/components/shared/GoogleAutoComplete/GoogleAutoComplete.tsx
@@ -25,6 +25,7 @@ class GoogleAutoComplete extends React.Component<Props, any> {
   
   componentDidMount() {
     if (!this.props.inputRef.current) return;
+    if (!window.google) return;
 
     this.autocomplete = new google.maps.places.Autocomplete(
       this.props.inputRef.current,


### PR DESCRIPTION
## Description
This resolves `google is not defined` errors reported by Sentry, which occur when the Google Maps API fails to load asynchronously.

We clobbered our error-handling in #55; fortunately, we made the error a lot easier to handle in the process: In `componentDidMount`, proceed to wire up the Autocomplete only when `google` is defined. Otherwise, the text input shown just remains a text input, and search queries already gracefully degrade when only the text (and not coordinates) are available for a query.

## How to Test
1. Change `googleMapsUrl` to something that will fail too load
    1. In `shared/GoogleMaps`
    2. And `shared/GoogleMapsWithMarkers`
    3. And `shared/GoogleAutoComplete`
2. Go to main page
3. Verify that main page loads
4. Enter a search query
5. Verify that search with plain text functions as expected

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
History shows: As long as there is a `google` to not be defined, we *will* find a way to reintroduce that error.

## Learnings
This is a good example of dependencies introducing more work for us; working around the error in StandaloneSearchBox took a lot more code than just implementing the functionality we needed with Google APIs directly.