### PR TITLE
sharedBathroom default 'No'. Allow click 'Save & Continue' while form is pristine

### DIFF
--- a/src/components/routes/Host/ListingForm/ListingForm.tsx
+++ b/src/components/routes/Host/ListingForm/ListingForm.tsx
@@ -48,7 +48,7 @@ const defaultValues: FormValues = {
   postalCode: '',
   pricePerNightUsd: 100,
   securityDepositUsd: 50,
-  sharedBathroom: '',
+  sharedBathroom: 'No',
   sleepingArrangement: '',
   state: '',
   title: '',
@@ -142,6 +142,7 @@ class ListingForm extends React.Component<Props, State> {
       <ListingFormContainer>
         <Formik
           initialValues={populateListingForm(defaultValues, props.listing)}
+          isInitialValid
           validationSchema={ListingFormSchema}
           onSubmit={(values: ListingInput, actions: FormikActions<FormValues>) => {
             actions.setSubmitting(true);


### PR DESCRIPTION
## Description
Why did you write this code?
sharedBathroom field required is stifling users from publishing listings.
https://beetoken.atlassian.net/browse/ENG-917

**Not sure if we should make a backend change instead / as well. There are listings with `sharedBathroom: ''` which could be empty string forever if we remove it as a required.

## How to Test
- [x] Create a listing and publish without touching sharedBathroom.

- [x] Click `Save & Continue` without touching the form and the app should proceed successfully

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

