### PR TITLE
Improve initial zoom for Google Map on search

### DIFF
--- a/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
+++ b/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
@@ -48,19 +48,18 @@ const ListingQuery = () => {
   const { bounds, checkInDate, checkOutDate, coordinates, numberOfGuests, locationQuery } = queryParams;
   const areBoundsValid = bounds && bounds.east && bounds.north && bounds.south && bounds.west;
   const areCoordinatesValid = coordinates && coordinates.lat && coordinates.lng;
+  const parsedBounds = areBoundsValid && !!bounds ? {
+    east: parseFloat(bounds.east),
+    north: parseFloat(bounds.north),
+    south: parseFloat(bounds.south),
+    west: parseFloat(bounds.west),
+  } : undefined;
   const input = {
     checkInDate: checkInDate && isValid(new Date(checkInDate)) ? checkInDate : '',
     checkOutDate: checkOutDate && isValid(new Date(checkOutDate)) ? checkOutDate : '',
     numberOfGuests: numberOfGuests ? parseInt(numberOfGuests) : 1,
     locationQuery: locationQuery || '',
-    ...(areBoundsValid && !!bounds && {
-      bounds: {
-        east: parseFloat(bounds.east),
-        north: parseFloat(bounds.north),
-        south: parseFloat(bounds.south),
-        west: parseFloat(bounds.west),
-      }
-    }),
+    ...(areBoundsValid && { bounds: parsedBounds }),
     ...(areCoordinatesValid && {
       coordinates: {
         lat: coordinates && coordinates.lat ? parseFloat(coordinates.lat) : 0,
@@ -92,7 +91,9 @@ const ListingQuery = () => {
             {({ show, toggle }: ToggleProviderRef ) => (
               <div className={`listing-query-body${show ? ' listing-query-body--map-showing' : ''}`}>
                 <aside className="listing-query-body--map">
-                  <ListingsResultMap listings={data.searchListings}
+                  <ListingsResultMap
+                    bounds={parsedBounds}
+                    listings={data.searchListings}
                     toggle={toggle}
                     show={show} />
                 </aside>

--- a/src/components/routes/Listing/ListingsResult/ListingsResultMap.tsx
+++ b/src/components/routes/Listing/ListingsResult/ListingsResultMap.tsx
@@ -3,11 +3,12 @@ import * as React from 'react';
 import ErrorBoundaryWrapper from 'HOCs/ErrorBoundaryWrapper';
 import Checkbox from 'shared/Checkbox';
 import GoogleMapsWithMarkers from 'components/shared/GoogleMapsWithMarkers';
-import { ListingShort } from 'networking/listings';
+import { LatLngBounds, ListingShort } from 'networking/listings';
 
 interface Props {
   toggle: () => void;
   show: boolean;
+  bounds?: LatLngBounds;
   listings: ListingShort[];
 }
 
@@ -26,7 +27,7 @@ export default class ListingsResultMap extends React.Component<Props, State> {
   }
 
   render() {
-    const { show, toggle, listings } = this.props;
+    const { show, toggle, listings, bounds } = this.props;
     if (this.state.error) {
       return <></>;
     }
@@ -38,7 +39,7 @@ export default class ListingsResultMap extends React.Component<Props, State> {
           </Checkbox>
         </form>
         <ErrorBoundaryWrapper onError={this.handleError}>
-          {show && <GoogleMapsWithMarkers listings={listings} />}
+          {show && <GoogleMapsWithMarkers listings={listings} bounds={bounds} />}
         </ErrorBoundaryWrapper>
       </>
     );

--- a/src/components/shared/GoogleAutoComplete/GoogleAutoComplete.tsx
+++ b/src/components/shared/GoogleAutoComplete/GoogleAutoComplete.tsx
@@ -12,6 +12,7 @@ const { GOOGLE_MAPS_KEY } = SETTINGS;
 interface Props {
   defaultValue?: string;
   inputRef: React.RefObject<HTMLInputElement>;
+  onChange(): void;
   onPlaceChange(place: google.maps.places.PlaceResult): void;
 }
 
@@ -44,7 +45,7 @@ class GoogleAutoComplete extends React.Component<Props, any> {
       <GoogleAutoCompleteContainer>
         <InputWrapper box>
           <input
-            onChange={() => this.props.onPlaceChange({})}
+            onChange={() => this.props.onChange()}
             ref={this.props.inputRef}
             id="locationQuery"
             name="locationQuery"

--- a/src/components/shared/GoogleAutoComplete/GoogleAutoComplete.tsx
+++ b/src/components/shared/GoogleAutoComplete/GoogleAutoComplete.tsx
@@ -44,6 +44,7 @@ class GoogleAutoComplete extends React.Component<Props, any> {
       <GoogleAutoCompleteContainer>
         <InputWrapper box>
           <input
+            onChange={() => this.props.onPlaceChange({})}
             ref={this.props.inputRef}
             id="locationQuery"
             name="locationQuery"

--- a/src/components/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/components/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -7,11 +7,12 @@ import { SETTINGS } from 'configs/settings';
 const { GOOGLE_MAPS_KEY } = SETTINGS;
 
 import { ListingCard } from 'shared/ListingCard';
-import { ListingShort } from 'networking/listings';
+import { LatLngBounds, ListingShort } from 'networking/listings';
 
 import GoogleMapsWithMarkersContainer from './GoogleMapsWithMarkers.container';
 
 interface Props extends RouterProps {
+  bounds?: LatLngBounds;
   children?: React.ReactNode;
   className?: string;
   height?: string;
@@ -26,11 +27,22 @@ interface State {
 class GoogleMapsWithMarkers extends React.Component<Props, State> {
   state: State = {}
 
+  handleMapMounted = (map: GoogleMap) => {
+    const { bounds } = this.props;
+    if (bounds && map) {
+      map.fitBounds(bounds);
+    }
+  }
+
   render() {
     const { listings } = this.props;
     const { selectedListing } = this.state;
     return (
-      <GoogleMap defaultZoom={10} defaultCenter={getCenterCoordinates(listings)}>
+      <GoogleMap
+        defaultZoom={10}
+        defaultCenter={getCenterCoordinates(listings)}
+        ref={this.handleMapMounted}
+      >
         {listings.map(listing => (
           <Marker key={listing.id}
             position={{ lat: listing.lat, lng: listing.lng }}

--- a/src/components/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/components/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -28,9 +28,26 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
   state: State = {}
 
   handleMapMounted = (map: GoogleMap) => {
-    const { bounds } = this.props;
-    if (bounds && map) {
+    if (!map) {
+      return;
+    }
+    const { bounds, listings } = this.props;
+    if (bounds) {
       map.fitBounds(bounds);
+      return;
+    }
+    if (listings && listings.length > 1) {
+      map.fitBounds(listings.reduce(({north, south, east, west}, {lat, lng}) => ({
+        north: Math.max(north, lat),
+        south: Math.min(south, lat),
+        east: Math.max(east, lng),
+        west: Math.min(west, lng)
+      }), {
+        north: -90,
+        south: 90,
+        east: -180,
+        west: 180
+      }));
     }
   }
 

--- a/src/components/shared/SearchBar/SearchBar.tsx
+++ b/src/components/shared/SearchBar/SearchBar.tsx
@@ -162,7 +162,9 @@ class SearchBar extends React.Component<RouterProps, State> {
   handleGuests = (event: React.ChangeEvent<HTMLInputElement>) => this.setState({ numberOfGuests: event.target.value });
   
   handlePlaceChange = (place: google.maps.places.PlaceResult) => {
-    if (!place.geometry) return;
+    if (!place.geometry) {
+      return this.setState({ coordinates: null, bounds: null });
+    }
     this.setState({
       coordinates: {
         lat: place.geometry.location.lat(),

--- a/src/components/shared/SearchBar/SearchBar.tsx
+++ b/src/components/shared/SearchBar/SearchBar.tsx
@@ -86,7 +86,12 @@ class SearchBar extends React.Component<RouterProps, State> {
         <form className="search-bar-form" onKeyPress={this.disableEnter} onSubmit={this.handleSubmit}>
           <div className="search-bar-form--location">
             <div className="search-bar-autocomplete-container">
-              <GoogleAutoComplete onPlaceChange={this.handlePlaceChange} inputRef={this.inputRef} defaultValue={locationQuery} />
+              <GoogleAutoComplete
+                onChange={this.handleChange}
+                onPlaceChange={this.handlePlaceChange}
+                inputRef={this.inputRef}
+                defaultValue={locationQuery}
+              />
             </div>
           </div>
           <AppConsumer>
@@ -160,11 +165,14 @@ class SearchBar extends React.Component<RouterProps, State> {
 
   handleOnFocusChange = (focusedInput: 'startDate' | 'endDate' | null) => this.setState({ focusedInput });
   handleGuests = (event: React.ChangeEvent<HTMLInputElement>) => this.setState({ numberOfGuests: event.target.value });
-  
+
+  handleChange = () => {
+    // handlePlaceChange will be called later, if the user selects from Autocomplete
+    return this.setState({ coordinates: null, bounds: null });
+  }
+
   handlePlaceChange = (place: google.maps.places.PlaceResult) => {
-    if (!place.geometry) {
-      return this.setState({ coordinates: null, bounds: null });
-    }
+    if (!place.geometry) return;
     this.setState({
       coordinates: {
         lat: place.geometry.location.lat(),

--- a/src/networking/listings.ts
+++ b/src/networking/listings.ts
@@ -120,6 +120,13 @@ export interface HostListingReservations {
   title: string;
 }
 
+export interface LatLngBounds {
+  east: number;
+  north: number;
+  south: number;
+  west: number;
+}
+
 export interface Price {
   currency: Currency;
   pricePerNight: number;


### PR DESCRIPTION
## Description
In some cases searching for a region (esp. a country) could result in an initial map state without listings being displayed; the map was centered at the center of all listings, but zoomed to a point where all listings were out of view.

This initializes map bounds in a more informed way, per the following priorities:

1. When explicit `bounds` are available (e.g. because the user chose a place from Autocomplete), initialize the map to use those.
2. Otherwise, iterate through listings to determine bounds from maximum/minimum latitude/longitude values
3. Finally, in the case where there is just one listing, just center on that with existing default zoom setting (this avoids the case where we "fit bounds" to a single point and zoom in way too much)

Note that the "over-zoom" mentioned in (3) is still reproducible if there is more than one listing but *all* listings have the same lat/lng coordinates. Think this is a corner case we can carry, at least for now.

## How to Test
1. Search for a place and select from the autocomplete dropdown
2. Verify that initial map position contains the full place you searched for
3. Now search for a place but just type it, without selecting from autocomplete
4. Verify that initial map position fits all listings associated with that query

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
We may want smarter handling of the case where all *n* listing results have the same coordinates. This seems generally unlikely in practice (a sole host in a locale with a single building with multiple listings would create the circumstances for this) and the consequences are minor (you need to zoom out for any useful context) so think this is reasonable for now.

## Learnings
[`GoogleMap`](https://tomchentw.github.io/react-google-maps/#googlemap) exposes the underlying [`Map`](https://developers.google.com/maps/documentation/javascript/reference/map#Map) interface via a `ref`, providing access to full functionality when the exposed props do not suffice