### PR TITLE
make unpublish notice more clear

### DIFF
--- a/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
@@ -53,6 +53,7 @@ const HostListingCardContainer = styled.article`
 
   .host-listing-notice {
     ${typography('caption', 3)};
+    max-width: 125px;
   }
 
   .host-listing-image {

--- a/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
@@ -48,8 +48,12 @@ const HostListingCardContainer = styled.article`
         }
       }
     }
+
   }
 
+   .host-listing-notice {
+    ${typography('caption', 3)};
+   }
 
   .host-listing-image {
     height: 100%;

--- a/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
@@ -51,9 +51,9 @@ const HostListingCardContainer = styled.article`
 
   }
 
-   .host-listing-notice {
+  .host-listing-notice {
     ${typography('caption', 3)};
-   }
+  }
 
   .host-listing-image {
     height: 100%;

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -62,11 +62,14 @@ const HostListingCard = (props: Props): JSX.Element => {
           </BeeLink>
           <Button background="core" color="white" size="small" onClick={() => deleteListing(id)}>
             Delete
-          </Button>          
+          </Button>
+          <div className='host-listing-publish'>
           <label htmlFor={`publish-${id}`} title={canPublish ? '' : INCOMPLETE_LISTING}>
             <span className={canPublish ? '' : 'host-listing-meta--disabled'}>Publish</span>
             <Switch checked={isActive} disabled={!canPublish} onColor={hexColor('correct')} onChange={() => toggleListing(id)} id={`publish-${id}`} />
           </label>
+          {!canPublish && <p className='host-listing-notice'>{INCOMPLETE_LISTING}</p>}
+          </div>
         </div>
       </div>
       <div className="host-listing-image">

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -18,7 +18,7 @@ interface Props extends HostListingShort {
   deleteListing: (id: string) => Promise<any>;
 }
 
-const INCOMPLETE_LISTING = "This listing is incomplete. Use the Edit button to complete all required fields to publish this listing.";
+const INCOMPLETE_LISTING = "This listing is incomplete. Click Edit to complete all required fields to publish.";
 
 const HostListingCard = (props: Props): JSX.Element => {
   const {

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -64,11 +64,11 @@ const HostListingCard = (props: Props): JSX.Element => {
             Delete
           </Button>
           <div className='host-listing-publish'>
-          <label htmlFor={`publish-${id}`} title={canPublish ? '' : INCOMPLETE_LISTING}>
-            <span className={canPublish ? '' : 'host-listing-meta--disabled'}>Publish</span>
-            <Switch checked={isActive} disabled={!canPublish} onColor={hexColor('correct')} onChange={() => toggleListing(id)} id={`publish-${id}`} />
-          </label>
-          {!canPublish && <p className='host-listing-notice'>{INCOMPLETE_LISTING}</p>}
+            <label htmlFor={`publish-${id}`} title={canPublish ? '' : INCOMPLETE_LISTING}>
+              <span className={canPublish ? '' : 'host-listing-meta--disabled'}>Publish</span>
+              <Switch checked={isActive} disabled={!canPublish} onColor={hexColor('correct')} onChange={() => toggleListing(id)} id={`publish-${id}`} />
+            </label>
+            {!canPublish && <p className='host-listing-notice'>{INCOMPLETE_LISTING}</p>}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
We got over 15 support emails wondering why publish is disabled.

## How to Test
- [ ] Visit /host/listings
- [ ] See text:
![screen shot 2019-01-28 at 10 59 13 am](https://user-images.githubusercontent.com/7976/51859424-f4b9ff80-22eb-11e9-89a6-e884a3707636.png)


## Learnings
Tooltips are too hidden

