### PR TITLE
Jeremy/eng 927 - condense tabnavbar and add padding for tab content

### DIFF
--- a/src/components/routes/Trips/Trips.container.ts
+++ b/src/components/routes/Trips/Trips.container.ts
@@ -129,6 +129,7 @@ const TripsContainerTablet = styled(TripsContainerMobile)`
         }
       }
       nav {
+        align-self: flex-start;
         margin-bottom: 40px;
       }
       .trips-book-now {
@@ -198,7 +199,6 @@ const TripsContainerDesktop = styled(TripsContainerTablet)`
         }
       }
       nav {
-        align-self: flex-start;
         margin-bottom: 60px;
       }
       .trips-book-now {

--- a/src/components/routes/Trips/Trips.tsx
+++ b/src/components/routes/Trips/Trips.tsx
@@ -79,7 +79,7 @@ class Trips extends React.Component<Props, State> {
                       to: '/trips/past',
                     },
                     {
-                      title: 'Cancelled /\nRejected',
+                      title: 'Cancelled / Rejected',  // \xa0 is a non-breaking space
                       to: '/trips/cancelled',
                     }
                   ]} />

--- a/src/components/routes/Trips/Trips.tsx
+++ b/src/components/routes/Trips/Trips.tsx
@@ -79,7 +79,7 @@ class Trips extends React.Component<Props, State> {
                       to: '/trips/past',
                     },
                     {
-                      title: 'Cancelled / Rejected',  // \xa0 is a non-breaking space
+                      title: 'Cancelled / Rejected',
                       to: '/trips/cancelled',
                     }
                   ]} />

--- a/src/components/shared/TabNav/TabNav.container.ts
+++ b/src/components/shared/TabNav/TabNav.container.ts
@@ -8,8 +8,9 @@ type Props = Partial<{
 
 const TabNavContainerMobile = styled.div`
   display: inline-block;
-  height: ${({ height }: Props) => height ? `${height}px` : '100%'};
   flex-grow: 1;
+  height: ${({ height }: Props) => height ? `${height}px` : '100%'};
+  min-width: 80px;
   position: relative;
 
 
@@ -35,10 +36,10 @@ const TabNavContainerMobile = styled.div`
       opacity: 0.5;
     }
     &.active {
-      background-color: ${color('white')};
+      background-color: ${color('secondary')};
       box-shadow: 0 2px 10px ${color('black', 0.1)};
       border-radius: 2px;
-      color: ${color('secondary')};
+      color: ${color('white')};
       position: relative;
       z-index: 1;
     }
@@ -58,6 +59,9 @@ const TabNavContainerTablet = styled(TabNavContainerMobile)`
   @media (min-width: 768px) {
     a {
       padding: 0 16px;
+      &.active {
+        border-radius: 2px;
+      }
       span {
         ${typography('title', 7)}
         word-break: normal;

--- a/src/components/shared/TabNav/TabNav.container.ts
+++ b/src/components/shared/TabNav/TabNav.container.ts
@@ -6,56 +6,64 @@ type Props = Partial<{
   tabWidth: number;
 }>;
 
-const TabNavContainer = styled.div`
-  display: flex;
+const TabNavContainerMobile = styled.div`
+  display: inline-block;
   height: ${({ height }: Props) => height ? `${height}px` : '100%'};
-  width: 100%;
   flex-grow: 1;
   position: relative;
 
-  .bee-tab-nav-item--container {
-    flex-grow: 1;
-    width: 100%;
-    height: 100%;
-    position: relative;
-    .alert-badge {
-      ${typography('title', 3)}
-      color: ${color('error')};
-      position: absolute;
-      right: 16px;
-      top: -16px;
-      z-index: 2;
+
+  .alert-badge {
+    ${typography('title', 3)}
+    color: ${color('error')};
+    position: absolute;
+    right: 16px;
+    top: -16px;
+    z-index: 2;
+  }
+  a {
+    ${typography('title', 7)}
+    align-items: center;
+    background-color: ${color('light')};
+    color: ${color('upper')};
+    display: flex;
+    height: inherit;
+    justify-content: center;
+    transition: all 0.2s ease-in-out;
+    width: inherit;
+    &:hover:not(.active) {
+      opacity: 0.5;
     }
-    .bee-tab-nav--item {
-      align-items: center;
-      display: flex;
-      height: inherit;
-      justify-content: center;
-      width: ${({ tabWidth }: Props) => tabWidth ? `${tabWidth}px` : '100%'};
-      a {
+    &.active {
+      background-color: ${color('white')};
+      box-shadow: 0 2px 10px ${color('black', 0.1)};
+      border-radius: 2px;
+      color: ${color('secondary')};
+      position: relative;
+      z-index: 1;
+    }
+    span {
+      ${typography('read', 3)}
+      text-align: center;
+      word-break: break-word;
+    }
+    .bee-svg {
+      height: 24px;
+      width: 24px;
+    }
+  }
+`;
+
+const TabNavContainerTablet = styled(TabNavContainerMobile)`
+  @media (min-width: 768px) {
+    a {
+      padding: 0 16px;
+      span {
         ${typography('title', 7)}
-        align-items: center;
-        background-color: ${color('light')};
-        color: ${color('upper')};
-        display: flex;
-        height: inherit;
-        justify-content: center;
-        transition: all 0.2s ease-in-out;
-        width: inherit;
-        &:hover:not(.active) {
-          opacity: 0.5;
-        }
-        &.active {
-          background-color: ${color('white')};
-          box-shadow: 0 2px 10px ${color('black', 0.1)};
-          border-radius: 2px;
-          color: ${color('secondary')};
-          position: relative;
-          z-index: 1;
-        }
+        word-break: normal;
       }
     }
   }
 `;
 
-export default TabNavContainer;
+export default TabNavContainerTablet;

--- a/src/components/shared/TabNav/TabNav.container.ts
+++ b/src/components/shared/TabNav/TabNav.container.ts
@@ -18,7 +18,7 @@ const TabNavContainerMobile = styled.div`
     ${typography('title', 3)}
     color: ${color('error')};
     position: absolute;
-    right: 16px;
+    right: 8px;
     top: -16px;
     z-index: 2;
   }

--- a/src/components/shared/TabNav/TabNav.tsx
+++ b/src/components/shared/TabNav/TabNav.tsx
@@ -3,36 +3,34 @@ import * as React from 'react';
 import TabNavContainer from './TabNav.container';
 
 import BeeLink from 'shared/BeeLink';
+import Svg from 'shared/Svg';
+import { AppConsumer, AppConsumerProps, ScreenType } from 'components/App.context';
 
 interface Props {
-  config: Config[],
+  badge?: string;
   height?: number;
+  src?: string;
+  title: string;
+  to: string;
   width?: number;
 }
 
-interface Config {
-  badge?: string;
-  title: string;
-  to: string;
-}
-
 const TabNav = (props: Props): JSX.Element => {
-  const renderTabNavItems = props.config.map(({ badge, title, to }: Config) => {
-    return (
-      <div className="bee-tab-nav-item--container" key={title}>
-        {!!badge && <span className="alert-badge">{badge}</span>}
-        <div className="bee-tab-nav--item" key={title}>
-          <BeeLink isNav to={to}>
-            {title}
-          </BeeLink>
-        </div>
-      </div>
-    );
-  });
-
+  const { badge, src, title, to } = props;
   return (
     <TabNavContainer {...props}>
-      {renderTabNavItems}
+      {!!badge && <span className="alert-badge">{badge}</span>}
+      <BeeLink to={to} isNav activeClassName="active">
+        <AppConsumer>
+          {({ screenType }: AppConsumerProps) => {
+            if (screenType < ScreenType.TABLET) {
+              return src ? <Svg src={src} /> : <span>{title}</span>;
+            }
+
+            return <span>{title}</span>;
+          }}
+        </AppConsumer>
+      </BeeLink>
     </TabNavContainer>
   );
 }

--- a/src/components/shared/TabNavBar/TabNavBar.container.ts
+++ b/src/components/shared/TabNavBar/TabNavBar.container.ts
@@ -8,6 +8,7 @@ const TabNavBarContainerMobile = styled.nav`
 
 const TabNavBarTablet = styled(TabNavBarContainerMobile)`
   @media (min-width: 768px) {
+    height: 48px;
     width: auto;
     display: block;
   }

--- a/src/components/shared/TabNavBar/TabNavBar.container.ts
+++ b/src/components/shared/TabNavBar/TabNavBar.container.ts
@@ -1,88 +1,15 @@
 import styled from 'styled-components';
-import { color, typography } from 'styled/utils';
 
 const TabNavBarContainerMobile = styled.nav`
   height: 64px;
   width: 100%;
   display: flex;
-
-
-  .bee-tab-nav-item--container {
-    flex-grow: 1;
-    height: 100%;
-    position: relative;
-    width: 100%;
-    .alert-badge {
-      ${typography('title', 3)}
-      color: ${color('error')};
-      position: absolute;
-      right: 16px;
-      top: -16px;
-      z-index: 2;
-    }
-    a {
-      align-items: center;
-      background-color: ${color('light')};
-      color: ${color('secondary')};
-      display: flex;
-      flex-basis: 0;
-      flex-grow: 1;
-      flex-shrink: 0;
-      height: 64px;
-      justify-content: center;
-      transition: all .2s ease-in-out;
-      &.active {
-        background-color: ${color('secondary')};
-        box-shadow: 0 2px 10px ${color('black', 0.25)};
-        color: ${color('white')};
-        position: relative;
-        z-index: 1;
-      }
-      > span {
-        ${typography('read', 3)}
-        text-align: center;
-        word-break: break-word;
-      }
-      .bee-svg {
-        height: 24px;
-        width: 24px;
-      }
-    }
-  }
 `;
 
 const TabNavBarTablet = styled(TabNavBarContainerMobile)`
   @media (min-width: 768px) {
-    height: 48px;
-    width: 100%;
-
-
-    /* need to re-add styled here for last tab because it goes through a query
-    first so cannot put within the tab nav component */
-    a {
-      background-color: ${color('light')};
-      color: ${color('upper')};
-      height: 48px;
-      text-align: center;
-      transition: all 0.2s ease-in-out;
-      width: 132px;
-      &:hover:not(.active) {
-        opacity: 0.5;
-      }
-      &.active {
-        background-color: ${color('white')};
-        box-shadow: 0 2px 10px ${color('black', 0.1)};
-        border-radius: 2px;
-        color: ${color('secondary')};
-        position: relative;
-        z-index: 1;
-      }
-      > span {
-        ${typography('title', 7)}
-        text-align: center;
-        word-break: break-word;
-      }
-    }
+    width: auto;
+    display: block;
   }
 `;
 

--- a/src/components/shared/TabNavBar/TabNavBar.tsx
+++ b/src/components/shared/TabNavBar/TabNavBar.tsx
@@ -2,9 +2,6 @@ import * as React from 'react';
 
 import TabNavBarContainer from './TabNavBar.container';
 
-import { AppConsumer, AppConsumerProps, ScreenType } from 'components/App.context';
-import BeeLink from 'shared/BeeLink';
-import Svg from 'shared/Svg';
 import TabNav from 'shared/TabNav/TabNav';
 
 interface Props {
@@ -20,33 +17,9 @@ interface TabNavItem {
 
 const TabNavBar = ({ config }: Props): JSX.Element => (
   <TabNavBarContainer>
-    <AppConsumer>
-      {({ screenType }: AppConsumerProps) => {
-        if (screenType < ScreenType.TABLET) {
-          return (
-            <>
-              {config.map(({ badge, src, title, to}: TabNavItem)=> {
-                return (
-                  <div className="bee-tab-nav-item--container" key={to}>
-                    {!!badge && <span className="alert-badge">{badge}</span>}
-                    <BeeLink to={to} isNav activeClassName="active">
-                    {src
-                      ? <Svg src={src} />
-                      : <span>{title}</span>
-                    }
-                    </BeeLink>
-                  </div>
-                );
-              })}
-            </>
-          );
-        };
-
-        return (
-          <TabNav config={config} />
-        );
-      }}
-    </AppConsumer>
+    {config.map((tabNavItemProps: TabNavItem) => {
+      return <TabNav {...tabNavItemProps} key={tabNavItemProps.to} />
+    })}
   </TabNavBarContainer>
 );
 


### PR DESCRIPTION
## Description
Why did you write this code?
Consolidate TabNavBar. Make tabs adjust its size based on inner content length.

## How to Test
- [ ] Visit 'host/', '/trips', '/profile'
- [ ] Test Mobile, Tablet, Desktop -- make sure layout still looks presentable

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

