### PR TITLE
Handle case where host is undefined

### DIFF
--- a/src/components/Admin/AdminUsers/AdminUsersHostForm/AdminUsersHostForm.tsx
+++ b/src/components/Admin/AdminUsers/AdminUsersHostForm/AdminUsersHostForm.tsx
@@ -285,7 +285,7 @@ class AdminUsersHostForm extends React.Component<HostProps, HostFormState> {
   render() {
     const { errors } = this.state;
     const { about, btcWalletAddress, email, firstName, lastName, phoneNumber, profilePicUrl, walletAddress } = errors;
-    const { id, listingCount } = this.props.host;
+    const { id, listingCount } = this.props.host || { id: undefined, listingCount: undefined };
     const nameError = firstName.error || lastName.error;
     const nameSuccess = firstName.success && lastName.success;
     const $formError = this.state.isSubmitClicked && !this.isFormValid() ? 'opacity--1' : '';


### PR DESCRIPTION
...to unbreak Create Host, which uses the same form but provides no host object with which to initialize it.

## Description
Sentry raised some errors on `/admin/users/new`; these were caused by changes from #92, which utilize `listingCount` and `id` of a host. These properties are not present when creating a host, so a fallback is needed.

## How to Test
1. Navigate to `/admin/users`
2. Click Create Host
3. Verify that you see the "Create User Profile" form instead of crashing the app

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
What else did I break? 🙃

## Learnings
Test editing *and* creating when a change touches both.

