### PR TITLE
(Re)implement ETH payments

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -29,7 +29,7 @@ module.exports = {
     ERC20_ADDRESSES: {
       DAI: '0x909E4dbdef114c9B39078Df314177780b89d8062'
     },
-    UNIPAY_ADDRESS: '0xf6615278bd3EC063C173821cb14A5BD318D5A3bF'
+    UNIPAY_ADDRESS: '0xd660c8a75cf57d8314857ee5e92df58e28b2a3e0'
   },
   testnet: {
     BEENEST_HOST: 'https://testnet.beenest.io',
@@ -52,7 +52,7 @@ module.exports = {
     ERC20_ADDRESSES: {
       DAI: '0x909E4dbdef114c9B39078Df314177780b89d8062'
     },
-    UNIPAY_ADDRESS: '0xf6615278bd3EC063C173821cb14A5BD318D5A3bF'
+    UNIPAY_ADDRESS: '0xd660c8a75cf57d8314857ee5e92df58e28b2a3e0'
   },
   staging: {
     BEENEST_HOST: 'https://staging.beenest.io',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16347,6 +16347,17 @@
         }
       }
     },
+    "websocket": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
+      "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.11.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      }
+    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15416,6 +15416,18 @@
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.36",
         "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+      },
+      "dependencies": {
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -16333,16 +16345,6 @@
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
           "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
         }
-      }
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
       }
     },
     "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "styled-components": "^4.0.3",
     "url": "^0.11.0",
     "validator": "^10.7.1",
-    "web3": "^1.0.0-beta.35",
+    "web3": "^1.0.0-beta.36",
     "webpack": "^4.23.1",
     "yup": "^0.26.6"
   },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "validator": "^10.7.1",
     "web3": "1.0.0-beta.36",
     "webpack": "^4.23.1",
+    "websocket": "^1.0.28",
     "yup": "^0.26.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "styled-components": "^4.0.3",
     "url": "^0.11.0",
     "validator": "^10.7.1",
-    "web3": "^1.0.0-beta.36",
+    "web3": "1.0.0-beta.36",
     "webpack": "^4.23.1",
     "yup": "^0.26.6"
   },

--- a/src/ABIs/unipay.json
+++ b/src/ABIs/unipay.json
@@ -1,78 +1,119 @@
 [
-	{
-		"constant": false,
-		"inputs": [
-			{
-				"name": "_from",
-				"type": "address"
-			},
-			{
-				"name": "_token",
-				"type": "address"
-			},
-			{
-				"name": "_value",
-				"type": "uint256"
-			},
-			{
-				"name": "_deadline",
-				"type": "uint256"
-			}
-		],
-		"name": "collect",
-		"outputs": [],
-		"payable": false,
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"inputs": [
-			{
-				"name": "_factory",
-				"type": "address"
-			},
-			{
-				"name": "_recipient",
-				"type": "address"
-			},
-			{
-				"name": "_token",
-				"type": "address"
-			}
-		],
-		"payable": false,
-		"stateMutability": "nonpayable",
-		"type": "constructor"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "_token",
-				"type": "address"
-			},
-			{
-				"name": "_value",
-				"type": "uint256"
-			}
-		],
-		"name": "price",
-		"outputs": [
-			{
-				"name": "",
-				"type": "uint256"
-			},
-			{
-				"name": "",
-				"type": "uint256"
-			},
-			{
-				"name": "",
-				"type": "address"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	}
+  {
+    "inputs": [
+      {
+        "name": "_factory",
+        "type": "address"
+      },
+      {
+        "name": "_recipient",
+        "type": "address"
+      },
+      {
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "price",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "price",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "name": "_deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "collect",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "name": "_deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "pay",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  }
 ]

--- a/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -99,7 +99,7 @@ class SelectPaymentOption extends React.Component<Props> {
       if (beeQuote) {
         const total = beeQuote.guestTotalAmount;
         priceWithEther(web3.eth, total)
-          .then(price => (console.log(price), this.setState({ conversionRateFromBee: price / total })))
+          .then(price => this.setState({ conversionRateFromBee: price / total }))
           .catch(() => this.setState({ errorPricingToken: true }));
       }
     }

--- a/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -13,7 +13,7 @@ import InputLabel from 'shared/InputLabel';
 import SelectBoxWrapper from 'shared/SelectBoxWrapper';
 import Svg from 'shared/Svg';
 import { AppEnv, APP_ENV } from 'configs/settings';
-import { loadWeb3, priceWithToken } from 'utils/web3';
+import { loadWeb3, priceWithEther, priceWithToken } from 'utils/web3';
 
 interface Props {
   booking: Booking;
@@ -91,6 +91,15 @@ class SelectPaymentOption extends React.Component<Props> {
         const total = beeQuote.guestTotalAmount;
         priceWithToken(web3.eth, currency, total)
           .then(price => this.setState({ conversionRateFromBee: price / total }))
+          .catch(() => this.setState({ errorPricingToken: true }));
+      }
+    } else if (currency === Currency.ETH) {
+      const web3 = loadWeb3();
+      const beeQuote = this.props.booking.priceQuotes.find(q => q.currency === Currency.BEE);
+      if (beeQuote) {
+        const total = beeQuote.guestTotalAmount;
+        priceWithEther(web3.eth, total)
+          .then(price => (console.log(price), this.setState({ conversionRateFromBee: price / total })))
           .catch(() => this.setState({ errorPricingToken: true }));
       }
     }

--- a/src/components/routes/Booking/BookingPayment/BookingPayment.tsx
+++ b/src/components/routes/Booking/BookingPayment/BookingPayment.tsx
@@ -13,10 +13,17 @@ import BookingPaymentButton from './BookingPaymentButton';
 import BookingNavBar from '../BookingNavBar';
 import { AppConsumer, AppConsumerProps, ScreenType } from 'components/App.context';
 import { parseQueryString } from 'utils/queryParams';
-import { loadWeb3, priceWithToken } from 'utils/web3';
+import { loadWeb3, priceWithEther, priceWithToken } from 'utils/web3';
 
 interface QueryParams {
   currency?: string;
+}
+
+function getSwapPrice(currency: Currency, amount: number) {
+  const web3 = loadWeb3();
+  return currency === Currency.ETH ?
+    priceWithEther(web3.eth, amount) :
+    priceWithToken(web3.eth, currency, amount);
 }
 
 const BookingPayment = ({ history, match }: RouterProps) => (
@@ -41,9 +48,8 @@ const BookingPayment = ({ history, match }: RouterProps) => (
       }
       const queryParams: QueryParams = parseQueryString(location.search);
       const currency = Object.values(Currency).find(c => c === queryParams.currency);
-      const web3 = loadWeb3();
       const pricePromise = !!currency && currency !== booking.currency ?
-        priceWithToken(web3.eth, currency, booking.guestTotalAmount) :
+        getSwapPrice(currency, booking.guestTotalAmount) :
         Promise.resolve(booking.guestTotalAmount);
       return (
         <Async promise={pricePromise} then={price => {

--- a/src/components/routes/Booking/BookingPayment/BookingPaymentButton.tsx
+++ b/src/components/routes/Booking/BookingPayment/BookingPaymentButton.tsx
@@ -9,7 +9,7 @@ import Button from 'shared/Button';
 import Portal from 'shared/Portal';
 import GridLoading from 'shared/loading/GridLoading';
 import CryptoPortal from 'shared/CryptoPortal';
-import { Web3Data, isNetworkValid, payWithBee, payWithEth, payWithToken, getValidNetworkName, loadWeb3 } from 'utils/web3';
+import { Web3Data, isNetworkValid, payWithBee, payWithEther, payWithToken, getValidNetworkName, loadWeb3 } from 'utils/web3';
 
 interface Props {
   booking: Booking;
@@ -143,11 +143,12 @@ async function getCryptoParams(
   if (fromBee && currency) {
     return payWithToken(web3.eth, paymentOptions, currency, fromBee);
   }
+  if (fromBee && booking.currency === Currency.ETH) {
+    return payWithEther(web3.eth, paymentOptions, fromBee(booking.guestTotalAmount));
+  }
   switch (booking.currency) {
     case Currency.BEE:
       return payWithBee(web3.eth, paymentOptions);
-    case Currency.ETH:
-      return payWithEth(web3.eth, paymentOptions, booking);
     default:
       alert('There was an error in submitting your payment. Please contact us at support@beetoken.com');
       throw new Error('INVALID_CRYPTO_CURRENCY_AT_BOOKING_PAYMENT');

--- a/src/components/routes/Booking/BookingPayment/BookingPaymentButton.tsx
+++ b/src/components/routes/Booking/BookingPayment/BookingPaymentButton.tsx
@@ -141,10 +141,9 @@ async function getCryptoParams(
     transactionFee: priceQuote.transactionFee,
   };
   if (fromBee && currency) {
-    return payWithToken(web3.eth, paymentOptions, currency, fromBee);
-  }
-  if (fromBee && booking.currency === Currency.ETH) {
-    return payWithEther(web3.eth, paymentOptions, fromBee(booking.guestTotalAmount));
+    return currency === Currency.ETH ?
+      payWithEther(web3.eth, paymentOptions, fromBee(booking.guestTotalAmount)) :
+      payWithToken(web3.eth, paymentOptions, currency, fromBee);
   }
   switch (booking.currency) {
     case Currency.BEE:

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -174,54 +174,25 @@ export async function payWithBee(ethProvider: Web3['eth'], paymentOptions: Payme
 export async function payWithEth(
   ethProvider: Web3['eth'],
   paymentOptions: PaymentOptions,
-  booking: Booking
+  ethPrice: number
 ): Promise<CryptoParams> {
-  const {
-    amount,
-    guestWalletAddress,
-    hostWalletAddress,
-    priceTotalNights,
-    securityDeposit,
-    transactionFee,
-  } = paymentOptions;
-  const { checkInDate, checkOutDate, id } = booking;
-
-  // Note on date conversions here:
-  // - checkInDate/checkOutDate are ISO date-strings
-  // - JS Dates are in milliseconds since 1970
-  // - EVM timestamps are in seconds since 1970
-  const cancelDeadline = Math.max(
-    Math.floor(new Date(checkInDate).valueOf() / 1000) - SEVEN_DAYS_IN_SEC,
-    Date.now() / 1000 + THIRTY_SIX_HOURS_IN_SEC
-  );
-  const dispatchDeadline = Math.floor(new Date(checkOutDate).valueOf() / 1000);
-  const amountWei = UNITS.WEI_PER_ETH.times(amount).toFixed(0);
-  const costWei = UNITS.WEI_PER_ETH.times(priceTotalNights).toFixed(0);
-  const cancelFeeWei = UNITS.WEI_PER_ETH.times(priceTotalNights * 0.1).toFixed(0);
-  const depositWei = UNITS.WEI_PER_ETH.times(securityDeposit).toFixed(0);
-  const transactionFeeWei = UNITS.WEI_PER_ETH.times(transactionFee).toFixed(0);
-  const paymentId = `0x${id.padStart(64, '0')}`;
-
+  const { amount, guestWalletAddress } = paymentOptions;
+  const beeDust = UNITS.AMOUNT_PER_BEE.times(amount).toFixed(0);
+  const wei = UNITS.WEI_PER_ETH.time(ethPrice).toFixed(0);
   try {
-    const { methods } = new ethProvider.Contract(ETH_PAYMENT_ABI, ETH_PAYMENT_ADDRESS);
-    const { transactionHash } = await methods
-      .initAndPayEthPayment(
-        paymentId, // bytes32 paymentId,
-        guestWalletAddress, // address demandEntityAddress,
-        hostWalletAddress, // address supplyEntityAddress,
-        costWei, // uint256 cost,
-        depositWei, // uint256 securityDeposit,
-        cancelFeeWei, // uint256 demandCancellationFee,
-        0, // uint256 supplyCancellationFee,
-        cancelDeadline, // uint64 cancelDeadlineInS,
-        dispatchDeadline, // uint64 paymentDispatchTimeInS,
-        transactionFeeWei // uint256 transactionFee
-      )
-      .send({ from: guestWalletAddress, value: amountWei });
+    const unipay = new ethProvider.Contract(UNIPAY_ABI, UNIPAY_ADDRESS);
+    const deadline = (Date.now() / 1000 + 5 * 60).toFixed(0); // Five minutes from now.
+    const transactionHash: string = await new Promise<string>(
+      (resolve, reject) => unipay.methods.pay(beeDust, deadline)
+        .send({ from: guestWalletAddress, value: wei })
+        .once('transactionHash', resolve)
+        .on('error', reject)
+    );
     return {
-      guestWalletAddress,
+      guestWalletAddress: UNIPAY_ADDRESS, // This will be the address to invoice
       transactionHash,
-      paymentProtocolAddress: ETH_PAYMENT_ADDRESS,
+      paymentProtocolAddress: BEETOKEN_PAYMENT_ADDRESS,
+      tokenContractAddress: BEETOKEN_ADDRESS,
     };
   } catch (error) {
     console.error(error);

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -241,6 +241,22 @@ export async function payWithToken(
   }
 }
 
+export async function priceWithEther(
+  ethProvider: Web3['eth'],
+  beePrice: number
+): Promise<number> {
+  const beeDust = UNITS.AMOUNT_PER_BEE.times(beePrice).toFixed(0);
+  try {
+    const { methods } = new ethProvider.Contract(UNIPAY_ABI, UNIPAY_ADDRESS);
+    const [ wei ] = await methods.price(beeDust).call();
+    const ethPrice = Big(wei).div(UNITS.WEI_PER_ETH); // TODO: Not all tokens have 18 digits...
+    return parseFloat(ethPrice.valueOf());
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
 export async function priceWithToken(
   ethProvider: Web3['eth'],
   currency: Currency | string,

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -249,7 +249,7 @@ export async function priceWithEther(
   try {
     const { methods } = new ethProvider.Contract(UNIPAY_ABI, UNIPAY_ADDRESS);
     const [ wei ] = await methods.price(beeDust).call();
-    const ethPrice = Big(wei).div(UNITS.WEI_PER_ETH); // TODO: Not all tokens have 18 digits...
+    const ethPrice = Big(wei).div(UNITS.WEI_PER_ETH);
     return parseFloat(ethPrice.valueOf());
   } catch (error) {
     console.error(error);

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -16,19 +16,16 @@ import { Booking, Currency, CryptoParams } from 'networking/bookings';
 import { APP_ENV, SETTINGS, AppEnv } from 'configs/settings';
 import { BEE_TOKEN_ABI } from 'ABIs/beeToken';
 import { BEE_PAYMENT_ABI } from 'ABIs/beePayment';
-import { ETH_PAYMENT_ABI } from 'ABIs/ethPayment';
 import UNIPAY_ABI from 'ABIs/unipay.json';
 
 const {
   BEETOKEN_ADDRESS,
   BEETOKEN_PAYMENT_ADDRESS,
-  ETH_PAYMENT_ADDRESS,
   ERC20_ADDRESSES,
   UNIPAY_ADDRESS
 } = SETTINGS;
 const { utils } = Web3;
 
-const SEVEN_DAYS_IN_SEC = 7 * 24 * 60 * 60;
 const THIRTY_SIX_HOURS_IN_SEC = 36 * 60 * 60;
 
 export const UNITS = {
@@ -171,7 +168,7 @@ export async function payWithBee(ethProvider: Web3['eth'], paymentOptions: Payme
   }
 }
 
-export async function payWithEth(
+export async function payWithEther(
   ethProvider: Web3['eth'],
   paymentOptions: PaymentOptions,
   ethPrice: number

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -178,7 +178,7 @@ export async function payWithEth(
 ): Promise<CryptoParams> {
   const { amount, guestWalletAddress } = paymentOptions;
   const beeDust = UNITS.AMOUNT_PER_BEE.times(amount).toFixed(0);
-  const wei = UNITS.WEI_PER_ETH.time(ethPrice).toFixed(0);
+  const wei = UNITS.WEI_PER_ETH.times(ethPrice).toFixed(0);
   try {
     const unipay = new ethProvider.Contract(UNIPAY_ABI, UNIPAY_ADDRESS);
     const deadline = (Date.now() / 1000 + 5 * 60).toFixed(0); // Five minutes from now.


### PR DESCRIPTION
## Description
Reimplements ETH payments using Unipay to exchange ETH for BEE at payment-time

## How to Test
1. Make a new booking
2. Choose ETH as the payment type
3. Confirm payment via MetaMask
4. Verify in etherscan that Payments has been approved to withdraw the booking's price in BEE by the transaction

Which devices did you test on?
- [ ] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
There may be additional changes needed on the admin/approval side; need to investigate

Will also want to deploy Unipay to mainnet and enable ETH in production at some point. 

## Learnings
None.
