### PR TITLE
Allow same-day date selection

### DIFF
--- a/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import moment from 'moment';
 
 import { Booking, Currency } from 'networking/bookings';
 
@@ -14,6 +15,8 @@ import SelectBoxWrapper from 'shared/SelectBoxWrapper';
 import Svg from 'shared/Svg';
 import { AppEnv, APP_ENV } from 'configs/settings';
 import { loadWeb3, priceWithToken } from 'utils/web3';
+
+const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
 
 interface Props {
   booking: Booking;
@@ -34,9 +37,13 @@ class SelectPaymentOption extends React.Component<Props> {
   render() {
     const { currency, conversionRateFromBee, errorPricingToken } = this.state;
     const { booking } = this.props;
-    const showBee = !!booking.host.walletAddress;
-    const showEth = !!booking.host.walletAddress && APP_ENV !== AppEnv.PRODUCTION;
-    const showBtc = booking.priceQuotes.some(({ currency }) => currency === Currency.BTC);
+    const isTwoDaysFromNow =
+      moment.utc(booking.checkInDate).valueOf() > (Date.now() + TWO_DAYS_MS);
+    const showBee = isTwoDaysFromNow && !!booking.host.walletAddress;
+    const showEth = isTwoDaysFromNow && !!booking.host.walletAddress &&
+      APP_ENV !== AppEnv.PRODUCTION;
+    const showBtc = isTwoDaysFromNow &&
+      booking.priceQuotes.some(({ currency }) => currency === Currency.BTC);
     // The 1.01 multiplier below accounts for fluctuating exchange rates etc.
     const fromBee = errorPricingToken ?
       (() => '--.--' ) :

--- a/src/components/routes/Listing/Listing/BookingRequestCard/BookingRequestCard.tsx
+++ b/src/components/routes/Listing/Listing/BookingRequestCard/BookingRequestCard.tsx
@@ -169,16 +169,13 @@ class BookingRequestCard extends React.Component<Props, State> {
   }
 
   handleIsOutsideRange = (day: moment.Moment) => {
-    const utcDay = day
-      .clone()
-      .utc()
-      .set('hours', 0);
+    const utcDay = day.clone().utc().set('hours', 0);
     const firstDay = this.props.checkInDate ?
       moment.utc(this.props.checkInDate) :
-      moment.utc().startOf('day').add(2, 'days');
+      moment().startOf('day').utc().set('hours', 0);
     const lastDay = this.props.checkOutDate ?
       moment.utc(this.props.checkOutDate) :
-      moment.utc().startOf('day').add(6, 'months');
+      moment().startOf('day').utc().add(6, 'months');
     return utcDay.isBefore(firstDay) || utcDay.isAfter(lastDay);
   };
 


### PR DESCRIPTION
## Description
Don't block out two days in advance in the date picker for booking requests. This allows guests to make bookings on the day of stay.

## How to Test
1. View a listing without any bookings today
2. Verify that the current day is shown in the date picker
3. Proceed to book with check-in set to today
4. Verify that crypto options are not shown
5. Verify that USD payment completes as expected
6. View a new listing
7. Select a day more than 48 hours in advance, proceed to book
8. Verify that crypto payment options *do* show

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
We may want to change our approach to crypto payments to work with this

## Learnings
I hope time zones turn out to be a passing fad.
