### PR TITLE
Connect existing Stripe account

### DIFF
--- a/src/components/App.routes.tsx
+++ b/src/components/App.routes.tsx
@@ -24,7 +24,7 @@ import ListingsResult from './routes/Listing/ListingsResult';
 import Login from './routes/authentication/Login';
 import Logout from './routes/authentication/Logout';
 import SignUp from './routes/authentication/SignUp';
-import { StripeExpressComplete, StripeExpressNew } from './routes/Account/StripeExpress';
+import { StripeConnect, StripeExpressComplete, StripeExpressNew } from './routes/Account/StripeExpress';
 import FirebaseAccountEmailHandler from './routes/Account/FirebaseAccountEmailHandler';
 import Trips from './routes/Trips';
 import TripsReceipt from './routes/Trips/TripsReceipt';
@@ -47,6 +47,7 @@ const AppRoutes = () => (
         <AppContainer className="bee-app" {...bannerState}>
           <Switch>
             <Route exact path="/account/verify" component={FirebaseAccountEmailHandler} />
+            <Route exact path="/account/stripe/connect" component={StripeConnect} />
             <Route exact path="/account/stripe_express/new" component={StripeExpressNew} />
             <Route exact path="/account/stripe_express/complete" component={StripeExpressComplete} />
             <AuthenticatedRoute path="/account" component={Account} />

--- a/src/components/routes/Account/StripeExpress/StripeConnect.tsx
+++ b/src/components/routes/Account/StripeExpress/StripeConnect.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import AudioLoading from 'shared/loading/AudioLoading';
+
+import { SETTINGS } from 'configs/settings';
+
+const { BEENEST_HOST, STRIPE_CLIENT_ID } = SETTINGS;
+
+const REDIRECT_URL = `${BEENEST_HOST}/account/stripe_express/complete`;
+const STRIPE_REDIRECT = `https://connect.stripe.com/oauth/authorize?redirect_uri=${REDIRECT_URL}&response_type=code&client_id=${STRIPE_CLIENT_ID}&scope=read_write`;
+
+/**
+ * Used as a friendly redirect url on our domains to setup stripe express account for hosts.
+ * Ie, via emails.
+ * see https://stripe.com/docs/connect/standard-accounts#integrating-oauth for workflow
+ **/
+export const StripeConnect = () => {
+  window.location.assign(STRIPE_REDIRECT);
+  return <AudioLoading height={150} width={150} />;
+};
+

--- a/src/components/routes/Account/StripeExpress/index.ts
+++ b/src/components/routes/Account/StripeExpress/index.ts
@@ -1,2 +1,3 @@
 export { StripeExpressComplete } from './StripeExpressComplete';
 export { StripeExpressNew } from './StripeExpressNew';
+export { StripeConnect } from './StripeConnect';

--- a/src/components/routes/Host/HostPayments/HostPayments.container.ts
+++ b/src/components/routes/Host/HostPayments/HostPayments.container.ts
@@ -36,8 +36,12 @@ const HostPaymentsContainer = styled.section`
   .host-payments-section-container--links {
     margin-bottom: 32px;
     button {
-      margin-bottom: 12px;
       width: auto;
+    }
+    p {
+      ${typography('read', 3)};
+      color: ${color('top')};
+      margin-bottom: 18px;
     }
   }
 `

--- a/src/components/routes/Host/HostPayments/HostPayments.container.ts
+++ b/src/components/routes/Host/HostPayments/HostPayments.container.ts
@@ -7,8 +7,6 @@ const HostPaymentsContainer = styled.section`
   width: 624px;
 
   .host-payments-section-container {
-    align-items: flex-end;
-    display: flex;
     justify-content: space-between;
     width: inherit;
     margin-bottom: 8px;
@@ -26,9 +24,20 @@ const HostPaymentsContainer = styled.section`
     .bee-error-message {
       height: 32px;
     }
+  }
+
+  .host-payments-section-container--submit {
     button {
       margin-bottom: 32px;
       width: 182px;
+    }
+  }
+
+  .host-payments-section-container--links {
+    margin-bottom: 32px;
+    button {
+      margin-bottom: 12px;
+      width: auto;
     }
   }
 `

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -132,7 +132,7 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
           </div>
           <div className="host-payments-section-container host-payments-section-container--links">
             <BeeLink
-              href={(stripeAccountDashboardLink && stripeLoginLink) ? stripeLoginLink : `${BEENEST_HOST}/account/stripe_express/new`}
+              href={stripeLoginLink || stripeAccountDashboardLink || `${BEENEST_HOST}/account/stripe_express/new`}
               target="_blank">
               <Button background="secondary" color="white" size="small">
                 {stripeAccountDashboardLink

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -130,7 +130,7 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
               </p>
             </div>
           </div>
-          <div className="host-payments-section-container">
+          <div className="host-payments-section-container host-payments-section-container--links">
             <BeeLink
               href={(stripeAccountDashboardLink && stripeLoginLink) ? stripeLoginLink : `${BEENEST_HOST}/account/stripe_express/new`}
               target="_blank">
@@ -184,7 +184,7 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
                   </ErrorMessageWrapper>
                 </div>
               </div>
-              <div className="host-payments-section-container">
+              <div className="host-payments-section-container host-payments-section-container--submit">
                 <Button
                   type="submit"
                   background="secondary"

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -141,6 +141,11 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
                 }
               </Button>
             </BeeLink>
+            {!stripeAccountDashboardLink && <>
+              <Button background="secondary" color="white" size="small">
+                Connect Existing Stripe Account
+              </Button>
+            </>}
           </div>
           <Formik
             initialValues={{ btcWalletAddress: btcWalletAddress || '', ethWalletAddress: walletAddress || '' }}

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -19,7 +19,7 @@ import {
   SuccessMessage
 } from 'utils/validators';
 
-const { BEENEST_HOST, STRIPE_CLIENT_ID } = SETTINGS;
+const { BEENEST_HOST } = SETTINGS;
 const SNACKBAR_DURATION_MS = 5000;
 
 const HostPayments = (): JSX.Element => {

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -141,8 +141,7 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
                 }
               </Button>
             </BeeLink>
-            {!stripeAccountDashboardLink && <BeeLink
-              href={`https://connect.stripe.com/oauth/authorize?response_type=code&client_id=${STRIPE_CLIENT_ID}&scope=read_write`}>
+            {!stripeAccountDashboardLink && <BeeLink to="/account/stripe/connect" target="_blank">
               <Button background="secondary" color="white" size="small">
                 Connect Existing Stripe Account
               </Button>

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -137,12 +137,12 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
               <Button background="secondary" color="white" size="small">
                 {stripeAccountDashboardLink
                   ? 'Go To Stripe Dashboard'
-                  : 'Setup Stripe Account'
+                  : 'Create Stripe Express Account'
                 }
               </Button>
             </BeeLink>
             {!stripeAccountDashboardLink && <p>
-              This is only available to hosts in the United States and Canada.<br/>This account will be limited to receiving payouts from Beenest.
+              Stripe Express is only available to hosts in the United States and Canada.<br/>This account will be limited to receiving payouts from Beenest.
             </p>}
             {!stripeAccountDashboardLink && <BeeLink to="/account/stripe/connect" target="_blank">
               <Button background="secondary" color="white" size="small">

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -141,11 +141,17 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
                 }
               </Button>
             </BeeLink>
+            {!stripeAccountDashboardLink && <p>
+              This is only available to hosts in the United States and Canada. This account will be limited to receiving payouts from Beenest.
+            </p>}
             {!stripeAccountDashboardLink && <BeeLink to="/account/stripe/connect" target="_blank">
               <Button background="secondary" color="white" size="small">
                 Connect Existing Stripe Account
               </Button>
             </BeeLink>}
+            {!stripeAccountDashboardLink && <p>
+              Available in the United States and other countries. Select this if you have an existing Stripe account.
+            </p>}
           </div>
           <Formik
             initialValues={{ btcWalletAddress: btcWalletAddress || '', ethWalletAddress: walletAddress || '' }}

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -142,7 +142,7 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
               </Button>
             </BeeLink>
             {!stripeAccountDashboardLink && <p>
-              This is only available to hosts in the United States and Canada. This account will be limited to receiving payouts from Beenest.
+              This is only available to hosts in the United States and Canada.<br/>This account will be limited to receiving payouts from Beenest.
             </p>}
             {!stripeAccountDashboardLink && <BeeLink to="/account/stripe/connect" target="_blank">
               <Button background="secondary" color="white" size="small">
@@ -150,7 +150,7 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
               </Button>
             </BeeLink>}
             {!stripeAccountDashboardLink && <p>
-              Available in the United States and other countries. Select this if you have an existing Stripe account.
+              Available in the United States and other countries.<br/>Select this if you have an existing Stripe account.
             </p>}
           </div>
           <Formik

--- a/src/components/routes/Host/HostPayments/HostPayments.tsx
+++ b/src/components/routes/Host/HostPayments/HostPayments.tsx
@@ -19,7 +19,7 @@ import {
   SuccessMessage
 } from 'utils/validators';
 
-const { BEENEST_HOST } = SETTINGS;
+const { BEENEST_HOST, STRIPE_CLIENT_ID } = SETTINGS;
 const SNACKBAR_DURATION_MS = 5000;
 
 const HostPayments = (): JSX.Element => {
@@ -141,11 +141,12 @@ class EnhancedComponent extends React.Component<Props, HostPaymentsContentState>
                 }
               </Button>
             </BeeLink>
-            {!stripeAccountDashboardLink && <>
+            {!stripeAccountDashboardLink && <BeeLink
+              href={`https://connect.stripe.com/oauth/authorize?response_type=code&client_id=${STRIPE_CLIENT_ID}&scope=read_write`}>
               <Button background="secondary" color="white" size="small">
                 Connect Existing Stripe Account
               </Button>
-            </>}
+            </BeeLink>}
           </div>
           <Formik
             initialValues={{ btcWalletAddress: btcWalletAddress || '', ethWalletAddress: walletAddress || '' }}


### PR DESCRIPTION
## Description
Some hosts have existing Stripe accounts; some hosts don't, but aren't eligible for Stripe Express and need a different option. This adds support for connecting existing Stripe accounts to beenest

## How to Test
1. Sign up for a [Stripe account](https://dashboard.stripe.com/register) with an unused email address
2. Sign up for a new beenest user account with the same email address
3. Navigate to `/host/payments`
4. Click "Connect Existing Stripe Account"
5. Fill out Stripe's form or "skip this step" (link should be available at the top)
6. Expect to be redirected to Beenest and see messaging celebrating your future income
7. Navigate to `/host/payments`
8. Expect to see a "Go to Stripe Dashboard" link instead of previous options
9. Click that button
10. Expect to be taken to the Stripe Dashboard. 

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Think we'll want to update some [paths](https://github.com/thebeetoken/beenest-web/pull/102#discussion_r252437497) which reference `stripe_express` but are used for Stripe generally

## Learnings
Stripe's different user account types have a lot of common functionality, which helped out a lot here
