### PR TITLE
Avoid initially-null form state

### DIFF
--- a/src/components/Admin/AdminUsers/AdminUsersHostForm/AdminUsersHostForm.tsx
+++ b/src/components/Admin/AdminUsers/AdminUsersHostForm/AdminUsersHostForm.tsx
@@ -110,7 +110,7 @@ class AdminUsersHostForm extends React.Component<HostProps, HostFormState> {
   state: any = {
     ...formHelper.generateDefaultState(),
     userForm: this.props.host
-      ? this.props.host
+      ? formHelper.generateInitialState(this.props.host).userForm
       : formHelper.generateDefaultState().userForm,
   };
 
@@ -120,7 +120,7 @@ class AdminUsersHostForm extends React.Component<HostProps, HostFormState> {
         id: this.props.host.id,
         isSubmitClicked: this.state.isSubmitClicked,
         errors: this.state.errors,
-        userForm: this.props.host,
+        userForm: formHelper.generateInitialState(this.props.host).userForm,
       });
     }
   }

--- a/src/utils/AdminFormHelper.tsx
+++ b/src/utils/AdminFormHelper.tsx
@@ -41,20 +41,17 @@ export const generateDefaultState = () => {
   };
 };
 
-export const generateDefaultFormState = (initialFormEntries: initialFormEntries) => {
+export const generateInitialState = (initialFormEntries: initialFormEntries) => {
+  const defaultState = generateDefaultState();
+  const filteredInitialState = Object.keys(initialFormEntries)
+    .filter(key => initialFormEntries[key] !== null && initialFormEntries[key] !== undefined)
+    .reduce((obj, key) => ({ ...obj, [key]: initialFormEntries[key] }), {});
   return {
-    message: 'Missing or invalid fields.',
-    isSubmitClicked: false,
-    status: {
-      ...Object.keys(initialFormEntries).map((field) => { 
-        return { [field]: generateErrorBoundary() }
-      })
-    },
-    form: {
-      ...initialFormEntries
-    },
-    isValid: false,
-    redirect: false
+    ...defaultState,
+    userForm: {
+      ...defaultState.userForm,
+      ...filteredInitialState
+    }
   };
 };
 


### PR DESCRIPTION
## Description
This fixes errors when editing a host, originally encountered when editing an ETH address on an account without a BTC address

## How to Test
1. Go to `/admin`
2. Edit an existing user who has an ethereum address but *not* a BTC address
3. Change the ethereum address, but don't touch the BTC address
4. Save
5. Expect save to complete successfully 

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
None expected

## Learnings
Hm, we had some dead code in there, I wonder if that's true elsewhere?

