### PR TITLE
Show pricing card when screen type is tablet

### DIFF
--- a/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -77,7 +77,7 @@ class SelectPaymentOption extends React.Component<Props> {
         </div>
         <AppConsumer>
           {({ screenType }: AppConsumerProps) =>
-            screenType > ScreenType.TABLET && (
+            screenType >= ScreenType.TABLET && (
               <div className="select-payment-quote-desktop">
                 <BookingQuote booking={booking} currency={currency || Currency.BEE} fromBee={fromBee} />
               </div>


### PR DESCRIPTION
## Description
During booking, the pricing card would disappear when selecting payment options with a "tablet" screen type, but the bottom bar would not appear until the screen type becomes "mobile"

This change shows the card when screen type is "tablet" or larger, consistent with what is displayed in subsequent booking steps.

## How to Test
1. Make a new booking
2. Play with the size of the window
3. Expect the bottom bar to appear whenever the pricing card disappears

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

