### PR TITLE
More Calendar link in host listings card

### DIFF
--- a/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
@@ -44,7 +44,7 @@ const HostListingCardContainer = styled.article`
       width: 555px;
       a,
       button {
-        min-width: 105px;
+        min-width: 125px;
       }
       label {
         display: inline-flex;

--- a/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
@@ -27,15 +27,15 @@ const HostListingCardContainer = styled.article`
       font-style: italic;
     }
     h4 {
-      ${typography('read', 1)};
-      color: ${color('upper')};
+      ${typography('read', 2)};
+      color: ${color('link')};
       display: block;
-      margin: 14px 0;
+      margin: 14px 0 18px;
       .bee-svg {
         display: inline-block;
-        height: 32px;
-        margin-bottom: -10px;
-        width: 32px;
+        height: 24px;
+        margin-bottom: -7px;
+        width: 24px;
       }
     }
     &--button-container {

--- a/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
@@ -25,7 +25,18 @@ const HostListingCardContainer = styled.article`
     h3 {
       ${typography('caption', 1)};
       font-style: italic;
-      margin-bottom: 14px;
+    }
+    h4 {
+      ${typography('read', 1)};
+      color: ${color('upper')};
+      display: block;
+      margin: 14px 0;
+      .bee-svg {
+        display: inline-block;
+        height: 32px;
+        margin-bottom: -10px;
+        width: 32px;
+      }
     }
     &--button-container {
       display: flex;

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -8,6 +8,7 @@ import HostListingCardContainer from './HostListingCard.container';
 import BeeLink from 'shared/BeeLink';
 import Button from 'shared/Button';
 import LazyImage from 'shared/LazyImage';
+import Svg from 'shared/Svg';
 import { ACTIVATE_LISTING, DEACTIVATE_LISTING, DELETE_LISTING, GET_HOST_LISTINGS, HostListingShort, Listing } from 'networking/listings';
 import { formatAddress } from 'utils/formatter';
 import { hexColor } from 'styled/utils';
@@ -41,18 +42,18 @@ const HostListingCard = (props: Props): JSX.Element => {
     <HostListingCardContainer className="host-listing-card">
       <div className="host-listing-meta">
         <h1>{title}</h1>
-        {(city || state || country) && <h2>{formatAddress(city, state, country)}</h2>}
+        <h2>{(city || state || country) ? formatAddress(city, state, country) : ''}</h2>
         <div className="bee-flex-div" />
         <h3>Last edited: {format(updatedAt, 'MM/DD/YY [at] hh:mmA')}</h3>
+        <h4>
+          <BeeLink to={`/host/listings/${id}/calendar`}>
+            View Calendar <Svg src="utils/carat-right" height="1em" />
+          </BeeLink>
+        </h4>
         <div className="host-listing-meta--button-container">
           <BeeLink to={`/host/listings/${id}/edit`}>
             <Button background="core" color="white" size="small">
               Edit
-            </Button>
-          </BeeLink>
-          <BeeLink to={`/host/listings/${id}/calendar`}>
-            <Button background="core" color="white" size="small">
-              Calendar
             </Button>
           </BeeLink>
           <BeeLink target="_blank" to={`/listings/${idSlug}`}>


### PR DESCRIPTION
## Description
Moves the Calendar link on a host's listing card from a button to text, per updated designs

Note that the updated design doesn't include "Last edited" text, so I made some judgment calls there

## How to Test
1. Go to `/host/listings`
2. Verify that "View Calendar >" shows under title and metadata of each listing
3. Verify that link still works

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
