### PR TITLE
Parameterize profile image resolution

### DIFF
--- a/src/components/routes/Listing/Listing/Listing.tsx
+++ b/src/components/routes/Listing/Listing/Listing.tsx
@@ -13,6 +13,8 @@ import { GET_PUBLIC_LISTING } from 'networking/listings';
 import AudioLoading from 'shared/loading/AudioLoading';
 import PopUpCard from 'shared/PopUpCard';
 
+const PROFILE_IMAGE_PARAMETERS = { width: 300, height: 300 };
+
 class Listing extends React.Component<RouterProps> {
   readonly state = {
     showCard: false,
@@ -21,9 +23,10 @@ class Listing extends React.Component<RouterProps> {
   toggleCard = () => this.setState({ showCard: !this.state.showCard });
 
   render() {
+    const { id } = this.props.match.params;
     return (
       <ListingContainer>
-        <Query query={GET_PUBLIC_LISTING} variables={{ id: this.props.match.params.id }}>
+        <Query query={GET_PUBLIC_LISTING} variables={{ id, ...PROFILE_IMAGE_PARAMETERS }}>
           {({ loading, error, data }) => {
             if (loading) {
               return <AudioLoading height={48} width={96} />;

--- a/src/networking/listings.ts
+++ b/src/networking/listings.ts
@@ -315,14 +315,14 @@ export const GET_LISTING_FORM = gql`
 
 export const GET_PUBLIC_LISTING = gql`
   ${LISTING_DETAILS_FRAGMENT}
-  query PublicListing($id: ID!) {
+  query PublicListing($id: ID!, $width: Int, $height: Int) {
     listing(id: $id) {
       host {
         id
         createdAt
         about
         firstName
-        profilePicUrl        
+        profilePicUrl(width: $width, height: $height)
       }
       ...ListingDetails
     }


### PR DESCRIPTION
## Description
Utilize image resizing when loading a host's profile photo to reduce bandwidth consumption

## How to Test
1. Visit a listing for which the host has a profile photo
2. Open the profile photo in a new tab
3. Verify that the image is less than 300x300 in resolution

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
There are other places where we use profile images which could also be reasonably resized
