### PR TITLE
swap basic textarea with Textarea component for the htmls

### DIFF
--- a/src/components/routes/Account/AccountGeneral/AccountGeneral.tsx
+++ b/src/components/routes/Account/AccountGeneral/AccountGeneral.tsx
@@ -14,6 +14,7 @@ import {
   getInputErrorClass,
   isNotEmpty,
 } from 'utils/validators';
+import Textarea from 'shared/Textarea';
 
 interface Props {
   user: User;
@@ -111,13 +112,12 @@ class AccountGeneral extends React.Component<Props, State> {
             </div> */}
             <div className="textarea-container">
               <InputLabel htmlFor="about">About</InputLabel>
-              <textarea
-                id="about"
+              <Textarea
+                html
                 name="about"
                 onChange={this.handleChange}
-                placeholder="Tell us about yourself"
-                value={form.about}>
-              </textarea>
+                value={form.about}
+                placeholder="Tell us about yourself" />
               <span
                 className={`bee-error-message ${getInputErrorClass(validation.about)}`.trim()}>
                 {errorMessages.isEmpty}


### PR DESCRIPTION
## Description
Why did you write this code?
Users aren't supposed to see raw HTML in text area 🤔
General Account 'About' section is a native text area while AdminUserForm 'About' is `<Textarea />` with html flag.

![image](https://user-images.githubusercontent.com/18321302/52141291-17a92400-260a-11e9-9804-aac66857b9f6.png)


## How to Test
- [ ] Visit `admin/users` and search your currently-signed-in user
- [ ] Fill out the 'About' section and save
- [ ] Go to accounts page and under 'General Info', see no html tags show up in 'About' Section

Which devices did you test on?
- [ ] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

