### PR TITLE
Show listing images in a grid

### DIFF
--- a/src/components/routes/Listing/Listing/ListingGallery.tsx
+++ b/src/components/routes/Listing/Listing/ListingGallery.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import LazyImage from 'shared/LazyImage';
+import ImageGrid from 'shared/ImageGrid';
 import Button from 'components/shared/Button';
 import { ToggleProvider, ToggleProviderRef } from 'components/shared/ToggleProvider';
 import CloseButton from 'components/shared/CloseButton';
@@ -15,12 +15,13 @@ interface Props {
 }
 
 const ListingGallery = ({ listingPicUrl, photos }: Props) => {
+  const images = [listingPicUrl].concat(photos);
   return (
     <div className="listing-gallery-container">
       <ToggleProvider>
         {({ show, toggle }: ToggleProviderRef) => (
           <>
-            <LazyImage src={listingPicUrl} onClick={toggle} transition />
+            <ImageGrid images={images} onClick={toggle} />
             <div className="listing-gallery-container--btn-wrapper">
               <Button
                 background="secondary"

--- a/src/components/shared/ImageGrid/ImageGrid.container.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.container.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+const ImageGridContainer = styled.div`
+  height: 100%;
+  position: relative;
+  width: 100%;
+  img {
+    height: 100%;
+    position: absolute;
+  }
+  img:nth-of-type(1) {
+    left: 0
+    width: 50%;
+  }
+  img:nth-of-type(2) {
+    height: 50%;
+    left: 50%;
+    top: 0;
+    width: 25%;
+  }
+  img:nth-of-type(3) {
+    height: 50%;
+    left: 75%;
+    top: 0;
+    width: 25%;
+  }
+  img:nth-of-type(4) {
+    height: 50%;    
+    left: 50%;
+    top: 50%;
+    width: 25%;
+  }
+  img:nth-of-type(5) {
+    height: 50%;
+    left: 75%;
+    top: 50%;
+    width: 25%;
+  }  
+`;
+
+/** @component */
+export default ImageGridContainer;

--- a/src/components/shared/ImageGrid/ImageGrid.container.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.container.tsx
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
 
+interface Props {
+  count?: number;
+}
+
 const ImageGridContainerMobile = styled.div`
   height: 100%;
   position: relative;
@@ -41,12 +45,16 @@ const ImageGridContainerTablet = styled(ImageGridContainerMobile)`
 
 const ImageGridContainer = styled(ImageGridContainerTablet)`
   @media (min-width: 1025px) {
-    img:nth-of-type(2) {
-      width: 25%;
-    }
-    img:nth-of-type(3) {
-      width: 25%;
-    }
+    ${({ count }: Props) => (!count || count < 4) ? '' : `
+      img:nth-of-type(2) {
+        width: 25%;
+      }
+    `}
+    ${({ count }: Props) => (!count || count < 5) ? '' : `
+      img:nth-of-type(3) {
+        width: 25%;
+      }
+    `}
     img:nth-of-type(4) {
       display: block;
       height: 50%;

--- a/src/components/shared/ImageGrid/ImageGrid.container.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.container.tsx
@@ -15,6 +15,7 @@ const ImageGridContainerMobile = styled.div`
   }
   img:nth-of-type(1) {
     display: block;
+    left: 0;
     width: 100%;
   }
 `;
@@ -22,13 +23,12 @@ const ImageGridContainerMobile = styled.div`
 const ImageGridContainerTablet = styled(ImageGridContainerMobile)`
   @media (min-width: 768px) {
     img:nth-of-type(1) {
-      display: block;
-      left: 0
-      width: 50%;
+      left: 0;
+      width: ${({ count }: Props) => (!count || count < 2) ? '100%' : '50%'};;
     }
     img:nth-of-type(2) {
       display: block;
-      height: 50%;
+      height: ${({ count }: Props) => (!count || count < 3) ? '100%' : '50%'};
       left: 50%;
       top: 0;
       width: 50%;

--- a/src/components/shared/ImageGrid/ImageGrid.container.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.container.tsx
@@ -45,16 +45,12 @@ const ImageGridContainerTablet = styled(ImageGridContainerMobile)`
 
 const ImageGridContainer = styled(ImageGridContainerTablet)`
   @media (min-width: 1025px) {
-    ${({ count }: Props) => (!count || count < 4) ? '' : `
-      img:nth-of-type(2) {
-        width: 25%;
-      }
-    `}
-    ${({ count }: Props) => (!count || count < 5) ? '' : `
-      img:nth-of-type(3) {
-        width: 25%;
-      }
-    `}
+    img:nth-of-type(2) {
+      width: ${({ count }: Props) => (!count || count < 4) ? '50%' : '25%'};
+    }
+    img:nth-of-type(3) {
+      width: ${({ count }: Props) => (!count || count < 5) ? '50%' : '25%'};
+    }
     img:nth-of-type(4) {
       display: block;
       height: 50%;

--- a/src/components/shared/ImageGrid/ImageGrid.container.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.container.tsx
@@ -1,41 +1,66 @@
 import styled from 'styled-components';
 
-const ImageGridContainer = styled.div`
+const ImageGridContainerMobile = styled.div`
   height: 100%;
   position: relative;
   width: 100%;
   img {
+    display: none;
     height: 100%;
     position: absolute;
   }
   img:nth-of-type(1) {
-    left: 0
-    width: 50%;
+    display: block;
+    width: 100%;
   }
-  img:nth-of-type(2) {
-    height: 50%;
-    left: 50%;
-    top: 0;
-    width: 25%;
+`;
+
+const ImageGridContainerTablet = styled(ImageGridContainerMobile)`
+  @media (min-width: 768px) {
+    img:nth-of-type(1) {
+      display: block;
+      left: 0
+      width: 50%;
+    }
+    img:nth-of-type(2) {
+      display: block;
+      height: 50%;
+      left: 50%;
+      top: 0;
+      width: 50%;
+    }
+    img:nth-of-type(3) {
+      display: block;
+      height: 50%;
+      left: 50%;
+      top: 50%;
+      width: 50%;
+    }
   }
-  img:nth-of-type(3) {
-    height: 50%;
-    left: 75%;
-    top: 0;
-    width: 25%;
-  }
-  img:nth-of-type(4) {
-    height: 50%;    
-    left: 50%;
-    top: 50%;
-    width: 25%;
-  }
-  img:nth-of-type(5) {
-    height: 50%;
-    left: 75%;
-    top: 50%;
-    width: 25%;
-  }  
+`;
+
+const ImageGridContainer = styled(ImageGridContainerTablet)`
+  @media (min-width: 1025px) {
+    img:nth-of-type(2) {
+      width: 25%;
+    }
+    img:nth-of-type(3) {
+      width: 25%;
+    }
+    img:nth-of-type(4) {
+      display: block;
+      height: 50%;
+      left: 75%;
+      top: 0;
+      width: 25%;
+    }
+    img:nth-of-type(5) {
+      display: block;
+      height: 50%;
+      left: 75%;
+      top: 50%;
+      width: 25%;
+    }
 `;
 
 /** @component */

--- a/src/components/shared/ImageGrid/ImageGrid.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.tsx
@@ -7,13 +7,15 @@ interface Props {
   onClick?: (url: string) => void;
 }
 
-const ImageGrid = ({ images, onClick }: Props) => (<ImageGridContainer>
-  {images.map((url, index) => (<LazyImage
-    src={url}
-    key={index}
-    onClick={() => onClick && onClick(url)}
-    transition
-  />))}
-</ImageGridContainer>);
+const ImageGrid = ({ images, onClick }: Props) => (
+  <ImageGridContainer count={images.length}>
+    {images.map((url, index) => (<LazyImage
+      src={url}
+      key={index}
+      onClick={() => onClick && onClick(url)}
+      transition
+    />))}
+  </ImageGridContainer>
+);
 
 export default ImageGrid;

--- a/src/components/shared/ImageGrid/ImageGrid.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.tsx
@@ -8,8 +8,8 @@ interface Props {
 }
 
 const ImageGrid = ({ images, onClick }: Props) => (
-  <ImageGridContainer count={images.length}>
-    {images.map((url, index) => (<LazyImage
+  <ImageGridContainer count={Math.min(images.length, 5)}>
+    {images.slice(0, Math.min(images.length, 5)).map((url, index) => (<LazyImage
       src={url}
       key={index}
       onClick={() => onClick && onClick(url)}

--- a/src/components/shared/ImageGrid/ImageGrid.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
 import LazyImage from 'shared/LazyImage';
+import ImageGridContainer from './ImageGrid.container';
 
 interface Props {
   images: string[];
   onClick?: (url: string) => void;
 }
 
-const ImageGrid = ({ images, onClick }: Props) => (<>
+const ImageGrid = ({ images, onClick }: Props) => (<ImageGridContainer>
   {images.map((url, index) => (<LazyImage
     src={url}
     key={index}
     onClick={() => onClick && onClick(url)}
     transition
   />))}
-</>);
+</ImageGridContainer>);
 
 export default ImageGrid;

--- a/src/components/shared/ImageGrid/ImageGrid.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import LazyImage from 'shared/LazyImage';
+
+interface Props {
+  images: string[];
+  onClick?: (url: string) => void;
+}
+
+const ImageGrid = (({ images, onClick }): Props) => (<>
+  {images.map((url, index) => (<LazyImage
+    src={url}
+    key={index}
+    onClick={() => onClick(url)}
+  />))}
+</>);
+
+export default ImageGrid;

--- a/src/components/shared/ImageGrid/ImageGrid.tsx
+++ b/src/components/shared/ImageGrid/ImageGrid.tsx
@@ -6,11 +6,12 @@ interface Props {
   onClick?: (url: string) => void;
 }
 
-const ImageGrid = (({ images, onClick }): Props) => (<>
+const ImageGrid = ({ images, onClick }: Props) => (<>
   {images.map((url, index) => (<LazyImage
     src={url}
     key={index}
-    onClick={() => onClick(url)}
+    onClick={() => onClick && onClick(url)}
+    transition
   />))}
 </>);
 

--- a/src/components/shared/ImageGrid/index.ts
+++ b/src/components/shared/ImageGrid/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ImageGrid';


### PR DESCRIPTION
## Description
This shows more images on the listing page, similar to what Airbnb does.

## How to Test
1. View a listing with 5 total image
2. View at desktop resolution
3. Verify that images are shown in grid (one on left, four on right)
4. View at tablet resolution
5. Verify that only three images are shown (one on left, two on right)
6. View at mobile resolution
7. Verify that just the one image is shown
8. Repeat for listings with 4, 3, 2, and 1 images
9. Verify that space gets filled sensibly when <5 (on desktop) or <3 (on tablet) images are present

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Clicking on an image opens the carousel, but does *not* start it with the clicked image being selected/shown. Think that's reasonable to punt to a subsequent PR

## Learnings
Whoa `styled` lets you pass Props into CSS!
