### PR TITLE
Jeremy/hotfix textarea: TypeCannot read property 'contentBlocks' of null

### DIFF
--- a/src/components/routes/Account/AccountGeneral/AccountGeneral.tsx
+++ b/src/components/routes/Account/AccountGeneral/AccountGeneral.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import AccountGeneralContainer from './AccountGeneral.container';
 
-import { UPDATE_USER, User } from 'networking/users';
+import { UPDATE_USER, User, GET_ACCOUNT_PAGE } from 'networking/users';
 import Button from 'shared/Button';
 import Divider from 'shared/Divider';
 import InputLabel from 'shared/InputLabel';
@@ -209,7 +209,9 @@ export default compose(
   graphql(UPDATE_USER, {
     props: ({ mutate }: any) => ({
       updateUser: (input: State): Promise<User> => {
-        return mutate({ variables: { input } });
+        return mutate({ variables: { input },
+          refetchQueries: [{ query: GET_ACCOUNT_PAGE }],
+        });
       },
     })
   })

--- a/src/components/shared/Textarea/Textarea.tsx
+++ b/src/components/shared/Textarea/Textarea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import TextareaContainer from './Textarea.container';
-import { Editor, EditorState, convertFromHTML, ContentState } from 'draft-js';
+import { Editor, EditorState, convertFromHTML, ContentState, ContentBlock } from 'draft-js';
 import { stateToHTML } from 'draft-js-export-html';
 
 /**
@@ -49,6 +49,10 @@ interface TextareaState {
 function createEditorState(string: string): EditorState {
   if (/<[a-z][\s\S]*>/i.test(string)) { // tests if there is html: https://stackoverflow.com/questions/15458876/check-if-a-string-is-html-or-not
     const blocksFromHTML = convertFromHTML(string);
+    if (!blocksFromHTML.contentBlocks) {
+      const contentState = ContentState.createFromText('');
+      return EditorState.createWithContent(contentState);
+    }
     const contentState = ContentState.createFromBlockArray(
       blocksFromHTML.contentBlocks,
       blocksFromHTML.entityMap

--- a/src/components/shared/Textarea/Textarea.tsx
+++ b/src/components/shared/Textarea/Textarea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import TextareaContainer from './Textarea.container';
-import { Editor, EditorState, convertFromHTML, ContentState, ContentBlock } from 'draft-js';
+import { Editor, EditorState, convertFromHTML, ContentState } from 'draft-js';
 import { stateToHTML } from 'draft-js-export-html';
 
 /**


### PR DESCRIPTION
## Description
Why did you write this code?
when a user clicks on a textarea, presses the return key and then submits, the values becomes
`<p><br/></p>`. The Draftjs method that converts a HTML string to real HTML doesn't recognize said string to make it into a ContentBlock and yields null. This catches that case and will render a blank text area instead of crashing.

https://sentry.io/beetoken/beenest/issues/869645122/?referrer=slack
https://sentry.io/beetoken/beenest/issues/870309426/?referrer=slack

## How to Test
- [ ] Visit 'account/general'
- [ ] Clear the text in 'About'
- [ ] Press Return for a new line
- [ ] Click Save
- [ ] refresh page and it shouldn't crash
---
- [ ] update the about
- [ ] click on 'Payment tab'
- [ ] click back to 'General Info'
- [ ] See that 'About' has most current saved entry.

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?
Yes. Right now new lines (expressed in `<p></br></p>`) aren't being rendered or processed by our textareas. Simply put, users cannot separate blocks of texts as of now due to the nature of the draft js conversion method.

## Learnings
Did you learn anything here you want to share with the team?
Draftjs documentation isn't super clear.
