### PR TITLE
Add Duplicate button

### DIFF
--- a/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.container.ts
@@ -35,7 +35,8 @@ const HostListingCardContainer = styled.article`
       width: 555px;
       a,
       button {
-        min-width: 125px;
+        min-width: 100px;
+        width: 100px;
       }
       label {
         display: inline-flex;

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -24,6 +24,7 @@ interface Props extends HostListingShort {
   activateListing: (id: string) => Promise<Listing>;
   deactivateListing: (id: string) => Promise<Listing>;
   deleteListing: (id: string) => Promise<any>;
+  duplicateListing: (ud: string) => Promise<Listing>;
 }
 
 const INCOMPLETE_LISTING = "This listing is incomplete. Click Edit to complete all required fields to publish.";

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -36,6 +36,7 @@ const HostListingCard = (props: Props): JSX.Element => {
     country,
     deactivateListing,
     deleteListing,
+    duplicateListing,
     id,
     idSlug,
     isActive,
@@ -68,6 +69,9 @@ const HostListingCard = (props: Props): JSX.Element => {
               Preview
             </Button>
           </BeeLink>
+          <Button background="core" color="white" size="small" onClick={() => duplicateListing(id)}>
+            Duplicate
+          </Button>
           <Button background="core" color="white" size="small" onClick={() => deleteListing(id)}>
             Delete
           </Button>

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -8,7 +8,15 @@ import HostListingCardContainer from './HostListingCard.container';
 import BeeLink from 'shared/BeeLink';
 import Button from 'shared/Button';
 import LazyImage from 'shared/LazyImage';
-import { ACTIVATE_LISTING, DEACTIVATE_LISTING, DELETE_LISTING, GET_HOST_LISTINGS, HostListingShort, Listing } from 'networking/listings';
+import {
+  ACTIVATE_LISTING,
+  DEACTIVATE_LISTING,
+  DELETE_LISTING,
+  DUPLICATE_LISTING,
+  GET_HOST_LISTINGS,
+  HostListingShort,
+  Listing
+} from 'networking/listings';
 import { formatAddress } from 'utils/formatter';
 import { hexColor } from 'styled/utils';
 
@@ -169,5 +177,25 @@ export default compose(
         });
       },
     }),
+  }),
+  graphql(DUPLICATE_LISTING, {
+    props: ({ mutate }: any) => ({
+      duplicateListing: (id: string) => mutate({
+        variables: { id },
+        refetchQueries: [{ query: GET_HOST_LISTINGS }],
+        update: (store: any, { data }: any) => {
+          if (!store.data.data.ROOT_QUERY || !store.data.data.ROOT_QUERY.hostListings) {
+            return;
+          }
+
+          const { duplicateListing } = data;
+          const { hostListings } = store.readQuery({ query: GET_HOST_LISTINGS });
+          store.writeQuery({
+            query: GET_HOST_LISTINGS,
+            data: { hostListings: [ duplicateListing, ...hostListings ] }
+          });
+        },
+      })
+    })
   })
 )(HostListingCard);

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -66,14 +66,14 @@ const HostListingCard = (props: Props): JSX.Element => {
             </Button>
           </BeeLink>
           <BeeLink target="_blank" to={`/listings/${idSlug}`}>
-            <Button background="core" color="white" size="small">
+            <Button background="white" border="core" color="core" size="small">
               Preview
             </Button>
           </BeeLink>
-          <Button background="core" color="white" size="small" onClick={() => duplicateListing(id)}>
+          <Button background="white" border="core" color="core" size="small" onClick={() => duplicateListing(id)}>
             Duplicate
           </Button>
-          <Button background="core" color="white" size="small" onClick={() => deleteListing(id)}>
+          <Button background="white" border="core" color="core" size="small" onClick={() => deleteListing(id)}>
             Delete
           </Button>
           <div className='host-listing-publish'>

--- a/src/networking/listings.ts
+++ b/src/networking/listings.ts
@@ -237,27 +237,35 @@ export const DELETE_LISTING = gql`
   }
 `;
 
+const HOST_LISTING_FRAGMENT = gql`
+  fragment HostListing on Listing {
+    canPublish
+    city
+    country
+    id
+    idSlug
+    isActive
+    listingPicUrl
+    state
+    title
+    updatedAt
+  }
+`;
+
 export const DUPLICATE_LISTING = gql`
+  ${HOST_LISTING_FRAGMENT}
   mutation DuplicateListing($id: ID!) {
     duplicateListing(id: $id) {
-      id
+      ...HostListing
     }
   }
 `;
 
 export const GET_HOST_LISTINGS = gql`
+  ${HOST_LISTING_FRAGMENT}
   query GetHostListings {
     hostListings {
-      canPublish
-      city
-      country
-      id
-      idSlug
-      isActive
-      listingPicUrl
-      state
-      title
-      updatedAt
+      ...HostListing
     }
   }
 `;

--- a/src/networking/listings.ts
+++ b/src/networking/listings.ts
@@ -237,6 +237,14 @@ export const DELETE_LISTING = gql`
   }
 `;
 
+export const DUPLICATE_LISTING = gql`
+  mutation DuplicateListing($id: ID!) {
+    duplicateListing(id: $id) {
+      id
+    }
+  }
+`;
+
 export const GET_HOST_LISTINGS = gql`
   query GetHostListings {
     hostListings {


### PR DESCRIPTION
## Description
Adds Duplicate as an option to listing cards in `/host/listings`, to make it easier to make more listings.

## How to Test
1. Navigate to `/host/listings` (and create at least one listing, if you don't have one)
2. Click "Duplicate" on a listing
3. Verify that a new listing named "Copy of..." appears
4. Verify that listing is initially unpublished


Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
UX attention here is minimal; future enhancements (e.g. wait spinners) would make sense

