### PR TITLE
Fix View Calendar link

### DIFF
--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -54,11 +54,11 @@ const HostListingCard = (props: Props): JSX.Element => {
         <h2>{(city || state || country) ? formatAddress(city, state, country) : ''}</h2>
         <div className="bee-flex-div" />
         <h3>Last edited: {format(updatedAt, 'MM/DD/YY [at] hh:mmA')}</h3>
-        <Button clear color="link" suffix="utils/carat-right">
-          <BeeLink to={`/host/listings/${id}/calendar`}>
+        <BeeLink to={`/host/listings/${id}/calendar`}>
+          <Button clear color="link" suffix="utils/carat-right">
             View Calendar
-          </BeeLink>
-        </Button>
+          </Button>
+        </BeeLink>
         <div className="host-listing-meta--button-container">
           <BeeLink to={`/host/listings/${id}/edit`}>
             <Button background="core" color="white" size="small">


### PR DESCRIPTION
## Description
The View Calendar link broke. [I broke it.](https://github.com/thebeetoken/beenest-web/pull/107) Sorry. This fixes it. Sorry.

## How to Test
1. Go to `/host/listings`
2. Click on View Calendar
3. Verify that you are taken to a calendar page

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
None expected.

## Learnings
`Button` goes in `BeeLink` to make a link button, not the other way around