### PR TITLE
Fix typo in 'latitude'

### DIFF
--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -14,7 +14,7 @@ interface FormatGeolocationAddress {
 }
 
 export function formatGeolocationAddress({ lat, lng, city, country }: FormatGeolocationAddress) {
-  return `Lattitude & Longitude: ${lat}, ${lng}, ${city}, ${country} `
+  return `Latitude & Longitude: ${lat}, ${lng}, ${city}, ${country} `
 }
 
 export function arrayToString(input: string[]): string {


### PR DESCRIPTION
## Description
Noticed a typo in #135 

## How to Test
This only shows on TripsReceipt (`/trips/:id/receipt`), and only when address fields aren't present; I'm not sure how to reproduce that situation so I just edited TripsReceipt to make sure the change looked sensible:

<img width="665" alt="image" src="https://user-images.githubusercontent.com/42747169/52244627-5998cb00-2893-11e9-897a-6b8453afb210.png">


Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
It is entirely possible we will make other spelling mistakes in the future.
