### PR TITLE
Hide verification inputs until after submit

### DIFF
--- a/src/components/routes/Account/AccountVerification/AccountVerificationPhoneCardContainer.ts
+++ b/src/components/routes/Account/AccountVerification/AccountVerificationPhoneCardContainer.ts
@@ -57,7 +57,7 @@ const AccountVerificationPhoneCardContainerMobile = styled.section`
   .verification-code-container {
     cursor: not-allowed;
     height: 96px;
-    opacity: 0.5;
+    opacity: 0;
     pointer-events: none;
     &.show {
       cursor: default;


### PR DESCRIPTION
## Description
During testing, noticed phone verification form is confusing: Inputs for the verification code are shown before a request for verification has been submitted. This hides those inputs completely.

## How to Test
1. Sign Up or Log In as a new, unverified user
2. Go to `/account/verification`
3. Click button to verify phone number
4. Expect text input for verification code not to display
5. Enter phone number, click "Submit Phone Number"
6. Expect input for verification code to display

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
None expected


