### PR TITLE
Check started bookings when choosing Trips tab

### DIFF
--- a/src/components/routes/Trips/Trips.tsx
+++ b/src/components/routes/Trips/Trips.tsx
@@ -61,7 +61,7 @@ class Trips extends React.Component<Props, State> {
                 return <h1>{error ? error.message : 'Error / No Data'}</h1>;
               }
               const { cancelled, current, past, started, upcoming } = data;
-              const isCurrentEmpty = !(current || []).length;
+              const isCurrentEmpty = !(current || []).length && !(started || []).length;
               const isUpcomingEmpty = !(upcoming || []).length;
               return (
                 <>


### PR DESCRIPTION
## Description
When determining which tab to choose by default at `/trips`, check the list of `started` bookings as well as `current` bookings. This means that if a user has an incomplete booking they will

## How to Test
1. Start a new booking (without completing)
2. Navigate to `/trips`
3. Verify that you are redirected to `/trips/current`, with a link to finish the booking you started

Note that the original issue is only reproducible if you have no "current" bookings; that is, all of the bookings shown in `/trips/current` should have "Continue Booking" links

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
None expected
