### PR TITLE
Frontend: Show alert on empty number field

### DIFF
--- a/src/components/routes/Host/ListingForm/ListingForm.tsx
+++ b/src/components/routes/Host/ListingForm/ListingForm.tsx
@@ -97,6 +97,7 @@ const ListingFormSchema = Yup.object().shape({
     .min(1, minNumberError('Max Guests'))
     .max(50, maxNumberError('Max Guests')),
   minimumNights: Yup.number()
+    .required('Minimum Nights is a required field.')
     .min(1, minNumberError('Minimum Nights')),
   numberOfBathrooms: Yup.number()
     .min(0, minNumberError('Number of Bathrooms')),
@@ -108,8 +109,10 @@ const ListingFormSchema = Yup.object().shape({
     .min(1, minStringError('Postal Code'))
     .max(45, maxStringError('Postal Code')),
   pricePerNightUsd: Yup.number()
+    .required('Price Per Night USD is a required field.')
     .min(1, minNumberError('Price Per Night')),
   securityDepositUsd: Yup.number()
+    .required('Security Deposit USD is a required field.')
     .min(0, minNumberError('Security Deposit')),
   sharedBathroom: Yup.string(),
   sleepingArrangement: Yup.string()

--- a/src/components/routes/Host/ListingForm/ListingFormNav/ListingFormNav.tsx
+++ b/src/components/routes/Host/ListingForm/ListingFormNav/ListingFormNav.tsx
@@ -65,7 +65,5 @@ const ListingFormNav = ({ formikProps, history, id, onSubmit, setNextCrumb, show
 export default ListingFormNav;
 
 function formatListingErrorsAlert(errors: FormikErrors<ListingInput>): string {
-  return `Listing has unsaved changes due to the following errors:\n\n
-    ${Object.values(errors).join('\n').toString()}\r\n\r\n
-    Are you sure you want to proceed?`;
+  return `Listing has unsaved changes due to the following errors:\n\n${Object.values(errors).join('\n').toString()}\n\nAre you sure you want to proceed?`;
 };

--- a/src/components/routes/Host/ListingForm/PricingAvailabilityForm/PricingAvailabilityForm.tsx
+++ b/src/components/routes/Host/ListingForm/PricingAvailabilityForm/PricingAvailabilityForm.tsx
@@ -36,7 +36,7 @@ const PricingAvailabilityForm = (props: any): JSX.Element => {
 
       <div className="form-item short">
         <div className="input-container">
-          <InputLabel htmlFor="minimumNights" subLabel="(required)">Min Nights</InputLabel>
+          <InputLabel htmlFor="minimumNights" subLabel="(required)">Minimum Nights</InputLabel>
           <InputWrapper>
             <Field
               name="minimumNights"


### PR DESCRIPTION
## Description
Why did you write this code?
Users try to submit after deleting the number values in the input.

This makes input type number fields required.
Also this should not affect submitting on other tabs since they are prefilled.

## How to Test
- [ ] Visit `host/listings/:id/pricing_availability`
- [ ] Remove Security Deposit, Price Per Night, and Minimum Nights values.
- [ ] Click `Save & Continue`
- [ ] Alert should show describing that the fields are required (should not hit backend)

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

