### PR TITLE
trim formatAddress, add country to the google maps query

### DIFF
--- a/src/components/routes/Host/ListingForm/ListingInfoForm/ListingInfoForm.tsx
+++ b/src/components/routes/Host/ListingForm/ListingInfoForm/ListingInfoForm.tsx
@@ -19,8 +19,8 @@ const LAT_LNG_EPSILON = Math.pow(10, -6); // decimal places stored in db
 
 const ListingInfoForm = (props: FormikProps<ListingInput>): JSX.Element => {
   const { errors, setFieldValue, setFieldTouched, values } = props;
-  const { addressLine1, city, postalCode, state } = values;
-  const address = formatAddress(addressLine1, city, state, postalCode);
+  const { addressLine1, city, country, postalCode, state } = values;
+  const address = formatAddress(addressLine1, city, state, postalCode, country);
   const StyledErrorMessage = (props: { name: string }) => (
     <ErrorMessageWrapper>
       {props.name && <ErrorMessage {...props} />}

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -3,7 +3,7 @@ import { Listing } from "networking/listings";
 // comma-separates terms and leaves no trailing commas
 export function formatAddress(...args: Array<string | undefined>): string {
   const clean = args.filter(str => !!str && !(str.toUpperCase() === 'US' || str.toUpperCase() === 'USA'));
-  return clean.slice(0, -1).join(', ') + ' ' + clean.slice(-1);
+  return (clean.slice(0, -1).join(', ') + (clean.slice(-1) ? ' ' + clean.slice(-1) : '')).trim();
 }
 
 interface FormatGeolocationAddress {


### PR DESCRIPTION
## Description
Why did you write this code?
After clicking 'Add New Listing', an error is shown in console. Found out the formatAddress was returning a space character ` ` instead of empty string. Google Maps doesn't like processing a single space character.
![image](https://user-images.githubusercontent.com/18321302/52368650-c92dc800-2a03-11e9-887f-d67f3d9cbb92.png)

## How to Test
- [x] Visit `/host/listings` and click Add New Listing
- [x] Verify no error is thrown in console and google maps display doesn't show error on initial listing.

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

