### PR TITLE
show error when toggle publish fails

### DIFF
--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -79,7 +79,12 @@ const HostListingCard = (props: Props): JSX.Element => {
           <div className='host-listing-publish'>
             <label htmlFor={`publish-${id}`} title={canPublish ? '' : INCOMPLETE_LISTING}>
               <span className={canPublish ? '' : 'host-listing-meta--disabled'}>Publish</span>
-              <Switch checked={isActive} disabled={!canPublish} onColor={hexColor('correct')} onChange={() => toggleListing(id)} id={`publish-${id}`} />
+              <Switch
+                checked={isActive}
+                disabled={!canPublish}
+                onColor={hexColor('correct')}
+                onChange={() => toggleListing(id).catch((error) => alert(error))}
+                id={`publish-${id}`} />
             </label>
             {!canPublish && <p className='host-listing-notice'>{INCOMPLETE_LISTING}</p>}
           </div>

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -5,6 +5,7 @@ import Switch from 'react-switch';
 
 import HostListingCardContainer from './HostListingCard.container';
 
+import { FirebaseConsumer, FirebaseUserProps } from 'HOCs/FirebaseProvider';
 import BeeLink from 'shared/BeeLink';
 import Button from 'shared/Button';
 import LazyImage from 'shared/LazyImage';
@@ -79,12 +80,18 @@ const HostListingCard = (props: Props): JSX.Element => {
           <div className='host-listing-publish'>
             <label htmlFor={`publish-${id}`} title={canPublish ? '' : INCOMPLETE_LISTING}>
               <span className={canPublish ? '' : 'host-listing-meta--disabled'}>Publish</span>
-              <Switch
-                checked={isActive}
-                disabled={!canPublish}
-                onColor={hexColor('correct')}
-                onChange={() => toggleListing(id).catch((error) => alert(error))}
-                id={`publish-${id}`} />
+              <FirebaseConsumer>
+                {({ completedVerification }: FirebaseUserProps) => {
+                  return (
+                    <Switch
+                      checked={isActive}
+                      disabled={!canPublish || !completedVerification}
+                      onColor={hexColor('correct')}
+                      onChange={() => toggleListing(id).catch((error) => alert(error))}
+                      id={`publish-${id}`} />
+                  );
+                }}
+              </FirebaseConsumer>
             </label>
             {!canPublish && <p className='host-listing-notice'>{INCOMPLETE_LISTING}</p>}
           </div>

--- a/src/components/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/components/routes/Host/HostListingCard/HostListingCard.tsx
@@ -29,6 +29,7 @@ interface Props extends HostListingShort {
 }
 
 const INCOMPLETE_LISTING = "This listing is incomplete. Click Edit to complete all required fields to publish.";
+const VERIFICATION_REQUIRED = "You must verify your email and phone to publish.";
 
 const HostListingCard = (props: Props): JSX.Element => {
   const {
@@ -77,24 +78,25 @@ const HostListingCard = (props: Props): JSX.Element => {
           <Button background="white" border="core" color="core" size="small" onClick={() => deleteListing(id)}>
             Delete
           </Button>
-          <div className='host-listing-publish'>
-            <label htmlFor={`publish-${id}`} title={canPublish ? '' : INCOMPLETE_LISTING}>
-              <span className={canPublish ? '' : 'host-listing-meta--disabled'}>Publish</span>
-              <FirebaseConsumer>
-                {({ completedVerification }: FirebaseUserProps) => {
-                  return (
-                    <Switch
-                      checked={isActive}
-                      disabled={!canPublish || !completedVerification}
-                      onColor={hexColor('correct')}
-                      onChange={() => toggleListing(id).catch((error) => alert(error))}
-                      id={`publish-${id}`} />
-                  );
-                }}
-              </FirebaseConsumer>
-            </label>
-            {!canPublish && <p className='host-listing-notice'>{INCOMPLETE_LISTING}</p>}
-          </div>
+          <FirebaseConsumer>
+            {({ completedVerification }: FirebaseUserProps) => {
+              return (
+                <div className='host-listing-publish'>
+                  <label htmlFor={`publish-${id}`} title={canPublish ? '' : INCOMPLETE_LISTING}>
+                    <span className={canPublish ? '' : 'host-listing-meta--disabled'}>Publish</span>
+                          <Switch
+                            checked={isActive}
+                            disabled={!canPublish || !completedVerification}
+                            onColor={hexColor('correct')}
+                            onChange={() => toggleListing(id).catch((error) => alert(error))}
+                            id={`publish-${id}`} />
+                  </label>
+                  {(!completedVerification || !canPublish) &&
+                    <p className='host-listing-notice'>{!completedVerification ? VERIFICATION_REQUIRED : INCOMPLETE_LISTING}</p>}
+                </div>
+              );
+            }}
+          </FirebaseConsumer>
         </div>
       </div>
       <div className="host-listing-image">


### PR DESCRIPTION
## Description
Why did you write this code?
Goes with https://github.com/thebeetoken/beenest-backend/pull/732
Before, error is only thrown in the console. This pops up an alert when publish fails.


## How to Test
- [ ] Switch Backend branch to https://github.com/thebeetoken/beenest-backend/pull/732
- [ ] Signup using a fake email.
- [ ] Visit 'host/listings' and make a new listing
- [ ] Toggling the publish should fail

Which devices did you test on?
- [ ] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

