### PR TITLE
add country to conference listing query

### DIFF
--- a/src/networking/conferences.ts
+++ b/src/networking/conferences.ts
@@ -90,6 +90,7 @@ export const GET_CONFERENCE = gql`
       link
       listings {
         city
+        country
         homeType
         id
         idSlug


### PR DESCRIPTION
## Description
Why did you write this code?
Under conference listings, country isn't being fetched but is needed for `ListingCard`

## How to Test
- [ ] Switch backend to `jeremy/ENG-821-fetch-country`
- [ ] Visit `http://localhost:4200/conferences/conference`
- [ ] In `src/components/routes/Conference` put a `console.log('conference:', conference);` before the return.
- [ ] See `country: USA` under conference listing

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

