### PR TITLE
hotfix calendar border

### DIFF
--- a/src/styled/containers/DateRangePicker.container.ts
+++ b/src/styled/containers/DateRangePicker.container.ts
@@ -589,7 +589,7 @@ const DateRangePickerContainer = styled.div`
     overflow-y: scroll;
   }
   .DateInput {
-    height: 40px;
+    height: 39px;
     margin: 0;
     padding: 0;
     background: #fff;
@@ -616,7 +616,7 @@ const DateRangePickerContainer = styled.div`
     font-family: 'Montserrat';
     ${typography('read', 1)}
     line-height: 1;
-    height: 40px;
+    height: 39px;
     background-color: #fff;
     width: 100%;
     padding: 0 0 0 16px;
@@ -716,7 +716,7 @@ const DateRangePickerContainer = styled.div`
     color: #484848;
     display: flex;
     flex-direction: column;
-    height: 41px;  /* need this since weird bottom border shows up at certain screen sizes */
+    height: 39px;
     justify-content: center;
     margin-left: 16px;
     margin-right: 20px;


### PR DESCRIPTION
## Description
Why did you write this code?
Check-in -> Check-out bottom border was 1px too low.

Before:
![image](https://user-images.githubusercontent.com/18321302/52437305-76b7de80-2acb-11e9-87cb-25bdae1b1890.png)

After:
![image](https://user-images.githubusercontent.com/18321302/52437318-7b7c9280-2acb-11e9-8399-c49b4d225e81.png)

## How to Test
- [ ] Visit `/`

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [x] Firefox on Mac
- [ ] Firefox on PC
- [x] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

