### PR TITLE
Update Unipay addresses on production

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -72,7 +72,7 @@ module.exports = {
     ERC20_ADDRESSES: {
       DAI: '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
     },
-    UNIPAY_ADDRESS: '0x21e1c35410cf17d8b71d1536e5cd9d8851e3a7fd'
+    UNIPAY_ADDRESS: '0x766Eeedd3e7cA0719cEd7d0a94DF4af9258a7E82'
   },
   production: {
     BEENEST_HOST: 'https://www.beenest.com',
@@ -94,6 +94,6 @@ module.exports = {
     ERC20_ADDRESSES: {
       DAI: '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
     },
-    UNIPAY_ADDRESS: '0x21e1c35410cf17d8b71d1536e5cd9d8851e3a7fd'
+    UNIPAY_ADDRESS: '0x766Eeedd3e7cA0719cEd7d0a94DF4af9258a7E82'
   },
 };


### PR DESCRIPTION
## Description
Updates to Unipay to provide Eth support have been deployed/tested on Ropsten; realized we haven't deployed the update to mainnet yet. (Should have caught this during #158; fortunately, any mainnet eth payment attempts will just fail without this change.)

## How to Test
Verify that ETH payments made in production (or with production-like environment variables) are directed to [0x766Eeedd3e7cA0719cEd7d0a94DF4af9258a7E82](https://etherscan.io/address/0x766eeedd3e7ca0719ced7d0a94df4af9258a7e82#code)

Which devices did you test on?
- [ ] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
