### PR TITLE
remove unused convertFromHTML

### DIFF
--- a/src/components/shared/Textarea/Textarea.tsx
+++ b/src/components/shared/Textarea/Textarea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import TextareaContainer from './Textarea.container';
-import { Editor, EditorState, convertFromHTML, ContentState } from 'draft-js';
+import { Editor, EditorState, ContentState } from 'draft-js';
 import { stateToHTML } from 'draft-js-export-html';
 import { stateFromHTML } from 'draft-js-import-html';
 


### PR DESCRIPTION
## Description
Why did you write this code?
On staging.beenest.io, the line breaks don't populate the textarea accordingly, but works fine on local. There is an unused import in the code -- maybe staging has really strict policies on that?

**maybe the staging deploy didn't go thru. should've been around 4pm but there are no beenest msgs on discord at that time.

## How to test
[ ] - Type into `about` section in account/general using line breaks
[ ] - Ensure they populate after saving and reloading.
[ ] - Verify staging fails to behave the same way.
