### PR TITLE
Show message for two-day crypto bookings.

### DIFF
--- a/src/components/routes/Booking/BookingOptions/BookingOptionsCrypto/BookingOptionsCrypto.tsx
+++ b/src/components/routes/Booking/BookingOptions/BookingOptionsCrypto/BookingOptionsCrypto.tsx
@@ -110,7 +110,7 @@ const BookingOptionsCrypto = ({ booking, currency, fromBee, history }: Props) =>
                     </div>
                   ))}
                 {!isTwoDaysFromNow && <div className="booking-options-error">
-                  <p>Bookings paid using Ethereum or ERC-20 tokens must be made at least two days in advance.</p>
+                  <p>Bookings paid using Ethereum or ERC-20 tokens must be made more than two days in advance.</p>
                 </div>}
                 <AppConsumer>
                   {({ screenType }: AppConsumerProps) => {

--- a/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/components/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import moment from 'moment';
 
 import { Booking, Currency } from 'networking/bookings';
 
@@ -14,8 +13,6 @@ import InputLabel from 'shared/InputLabel';
 import SelectBoxWrapper from 'shared/SelectBoxWrapper';
 import Svg from 'shared/Svg';
 import { loadWeb3, priceWithEther, priceWithToken } from 'utils/web3';
-
-const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
 
 interface Props {
   booking: Booking;
@@ -36,11 +33,9 @@ class SelectPaymentOption extends React.Component<Props> {
   render() {
     const { currency, conversionRateFromBee, errorPricingToken } = this.state;
     const { booking } = this.props;
-    const isTwoDaysFromNow =
-      moment.utc(booking.checkInDate).valueOf() > (Date.now() + TWO_DAYS_MS);
-    const showBee = isTwoDaysFromNow && !!booking.host.walletAddress;
-    const showEth = isTwoDaysFromNow && !!booking.host.walletAddress;
-    const showBtc = isTwoDaysFromNow &&
+    const showBee = !!booking.host.walletAddress;
+    const showEth = !!booking.host.walletAddress;
+    const showBtc =
       booking.priceQuotes.some(({ currency }) => currency === Currency.BTC);
     // The 1.01 multiplier below accounts for fluctuating exchange rates etc.
     const fromBee = errorPricingToken ?


### PR DESCRIPTION
## Description
Hiding BEE/ETH/DAI then a booking is less than two days in advance could be confusing for users. 

Instead, show BEE/ETH/DAI as options, but show a message and disable the button to continue.

## How to Test
1. Start to make a booking less than two days in advance
    1. Note that host must have an eth wallet
2. Verify that BEE, ETH, and DAI all appear as options
3. Select those options
4. Verify that button to continue booking is disabled, and that an informative message appears
5. Start a booking more than two days in advance
6. Verify that BEE/ETH/DAI can be paid for such a booking

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
