### PR TITLE
Expand search bounds

### DIFF
--- a/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
+++ b/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
@@ -26,13 +26,15 @@ const ListingsResult = () => (
   </ListingsResultContainer>
 );
 
+interface BoundsQueryParams {
+  east: string;
+  north: string;
+  south: string;
+  west: string;
+}
+
 interface QueryParams {
-  bounds?: {
-    east: string;
-    north: string;
-    south: string;
-    west: string;
-  };
+  bounds?: BoundsQueryParams;
   checkInDate?: string;
   checkOutDate?: string;
   coordinates?: {
@@ -43,12 +45,12 @@ interface QueryParams {
   locationQuery?: string;
 }
 
-const boundsToSearchParams = bounds => {
+const boundsToSearchParams = (bounds: BoundsQueryParams) => {
   // Add some padding to search bounds, e.g. to get Monterey Park from Los Angeles
-  const { east, west, south, north } = ['east', 'west', 'south', 'north'].reduce(
-    (parsedBounds, key) => ({ [key]: parseFloat(bounds[key]), ...parsedBounds }),
-    {}
-  );
+  const east = parseFloat(bounds.east);
+  const west = parseFloat(bounds.west);
+  const south = parseFloat(bounds.south);
+  const north = parseFloat(bounds.north);
   const latPad = (east - west) / 8;
   const lngPad = (north - south) / 8;
   return {

--- a/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
+++ b/src/components/routes/Listing/ListingsResult/ListingsResult.tsx
@@ -43,17 +43,28 @@ interface QueryParams {
   locationQuery?: string;
 }
 
+const boundsToSearchParams = bounds => {
+  // Add some padding to search bounds, e.g. to get Monterey Park from Los Angeles
+  const { east, west, south, north } = ['east', 'west', 'south', 'north'].reduce(
+    (parsedBounds, key) => ({ [key]: parseFloat(bounds[key]), ...parsedBounds }),
+    {}
+  );
+  const latPad = (east - west) / 8;
+  const lngPad = (north - south) / 8;
+  return {
+    east: east + latPad,
+    west: west - latPad,
+    north: north + lngPad,
+    south: south - lngPad
+  };
+};
+
 const ListingQuery = () => {
   const queryParams: QueryParams = parseQueryString(location.search);
   const { bounds, checkInDate, checkOutDate, coordinates, numberOfGuests, locationQuery } = queryParams;
   const areBoundsValid = bounds && bounds.east && bounds.north && bounds.south && bounds.west;
   const areCoordinatesValid = coordinates && coordinates.lat && coordinates.lng;
-  const parsedBounds = areBoundsValid && !!bounds ? {
-    east: parseFloat(bounds.east),
-    north: parseFloat(bounds.north),
-    south: parseFloat(bounds.south),
-    west: parseFloat(bounds.west),
-  } : undefined;
+  const parsedBounds = areBoundsValid && !!bounds ? boundsToSearchParams(bounds) : undefined;
   const input = {
     checkInDate: checkInDate && isValid(new Date(checkInDate)) ? checkInDate : '',
     checkOutDate: checkOutDate && isValid(new Date(checkOutDate)) ? checkOutDate : '',


### PR DESCRIPTION
## Description
Host reported that a listing in Monterey Park wasn't showing up in searches for Los Angeles; this expands search bounds relative to what Google tells us in order to get some of those nearby listings.

## How to Test
1. Search for Los Angeles
    1. Select "Los Angeles, CA" from Autocomplete so that the search uses Google's search bounds
2. Verify that listings for Monterey Park appear
    1. Note that we already see *one* such listing on dev without this change... Expect more? 

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
There are some circumstances for which we might want to make a similar change on the backend. Let's try this and see.
