### PR TITLE
Allow http for lazy images

### DIFF
--- a/src/components/shared/LazyImage/LazyImage.tsx
+++ b/src/components/shared/LazyImage/LazyImage.tsx
@@ -63,7 +63,7 @@ class LazyImage extends React.Component<LazyImageProps, LazyImageStateType> {
       <LazyImageContainer
         className={`${this.lazyImageContainerClasses} ${className ? className : ''}`.trim()}
         onClick={onClick}
-        src={src.startsWith('https') ? src : require(`../../../assets/images/${src}`)}
+        src={src.startsWith('http') ? src : require(`../../../assets/images/${src}`)}
         alt={alt}
         height={height}
         width={width}


### PR DESCRIPTION
## Description
Agoda image URLs use `http`, not `https`

## How to Test
Test with thebeetoken/beenest-backend#769; expect to see images for Agoda listings

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
thebeetoken/beenest-backend#769

