### PR TITLE
Remove double header

### DIFF
--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -136,7 +136,6 @@ const TEST_LISTINGS = [
 const Search = () => {
   return (
     <Fade>
-      <Header />
       <Row className="px-0 mx-0 bg-white sticky-top bee-top">
         <Col className="p-5" xs="12" lg="10" xl="9">
           <SearchBar />

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -4,7 +4,6 @@ import { Col, Fade, Row } from 'reactstrap';
 import GoogleMapsWithMarkers from 'shared/GoogleMapsWithMarkers';
 
 import Footer from 'components/work/Footer';
-import Header from 'components/work/Header';
 
 import SearchBar from 'components/work/SearchBar';
 import SearchForm from './SearchForm';


### PR DESCRIPTION
## Description
With #220, the Header is added to all pages in Work; this resulted in a second header appearing 

## How to Test
1. Visit /work/search
2. Verify that you see only one header atop the page

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Do we want to do same with Footer?

## Learnings
Two is not always better than one.