### PR TITLE
Use fixed-top for Header

### DIFF
--- a/src/components/work/Header/Header.tsx
+++ b/src/components/work/Header/Header.tsx
@@ -51,7 +51,7 @@ const DetailedHeader = () => {
   const [isOpen, toggleNavbar] = React.useState<boolean>(false);
 
   return (
-    <header className="sticky-top bg-white custom-header-height shadow" id="bee-main-header">
+    <header className="fixed-top bg-white custom-header-height shadow" id="bee-main-header">
       <Navbar light expand="md">
         <NavbarBrand href="/work">
           <BeenestSVGPrimary />

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -19,17 +19,19 @@ import '../styled/customStyles.scss';
 const Work = () => (
   <div>
     <Header />
-    <Switch>
-    <Route path="/work/about" component={About} />
-      <Route path="/work/account" component={Account} />
-      <Route exact path="/work/listings/:id" component={Listing} />
-      <Route exact path="/work/login" component={Login} />
-      <Route exact path="/work/logout" component={Logout} />
-      <Route exact path="/work/search" component={Search} />
-      <Route exact path="/work/signup" component={Signup} />
-      <AuthenticatedRoute path="/work/trips" component={Trips} />
-      <Route path="/work" component={Home} />
-    </Switch>
+    <main className="bee-top">
+      <Switch>
+      <Route path="/work/about" component={About} />
+        <Route path="/work/account" component={Account} />
+        <Route exact path="/work/listings/:id" component={Listing} />
+        <Route exact path="/work/login" component={Login} />
+        <Route exact path="/work/logout" component={Logout} />
+        <Route exact path="/work/search" component={Search} />
+        <Route exact path="/work/signup" component={Signup} />
+        <AuthenticatedRoute path="/work/trips" component={Trips} />
+        <Route path="/work" component={Home} />
+      </Switch>
+    </main>
   </div>
 );
 


### PR DESCRIPTION
## Description
@kcvan noted that the switch to `sticky-top` from #210 was causing the hamburger menu to push down content on tablet/mobile.

This proposed change goes back to `fixed-top`, so that the menu appears over content instead of pushing it down, and additionally adds a `main` tag with a `bee-top` class surrounding the top-level `Switch`, so that individual pages do not need to be concerned with this height (achieving the goal of #210 a different way)

## How to Test
1. View /work on mobile
2. Click hamburger menu
3. Expect content below to stay in place and get covered by menu

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Indirectly related: Should we bring in `Footer`?
