### PR TITLE
Link from ListingCard to Listing page

### DIFF
--- a/src/pages/search/ListingCard.tsx
+++ b/src/pages/search/ListingCard.tsx
@@ -5,24 +5,27 @@ import { ListingShort } from 'networking/listings';
 
 const ListingCard = ({
   homeType,
+  idSlug,
   listingPicUrl,
   pricePerNightUsd,
   title
 }: ListingShort) => (
-  <Card tag={Fade} className="w-100">
-    <div className="embed-responsive embed-responsive-4by3">
-      <div className="embed-responsive-item">
-        <CardImg className="w-100" src={listingPicUrl} alt={`Photo of ${title}`} />
+  <a href={`/work/listings/${idSlug}`} className="w-100 h-100">
+    <Card tag={Fade} className="w-100 h-100">
+      <div className="embed-responsive embed-responsive-4by3">
+        <div className="embed-responsive-item">
+          <CardImg className="w-100" src={listingPicUrl} alt={`Photo of ${title}`} />
+        </div>
       </div>
-    </div>
-    <CardBody>
-      <CardSubtitle>{homeType}</CardSubtitle>
-      <CardTitle tag="h5">{title}</CardTitle>
-    </CardBody>
-    <CardFooter>
-      <CardText>${pricePerNightUsd} per night</CardText>
-    </CardFooter>
-  </Card>
+      <CardBody>
+        <CardSubtitle>{homeType}</CardSubtitle>
+        <CardTitle tag="h5">{title}</CardTitle>
+      </CardBody>
+      <CardFooter>
+        <CardText>${pricePerNightUsd} per night</CardText>
+      </CardFooter>
+    </Card>
+  </a>
 );
 
 export default ListingCard;

--- a/src/pages/search/ListingCard.tsx
+++ b/src/pages/search/ListingCard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { Card, CardBody, CardFooter, CardImg, CardSubtitle, CardText, CardTitle, Fade } from 'reactstrap';
 
 import { ListingShort } from 'networking/listings';
@@ -10,7 +11,7 @@ const ListingCard = ({
   pricePerNightUsd,
   title
 }: ListingShort) => (
-  <a href={`/work/listings/${idSlug}`} className="w-100 h-100">
+  <Link to={`/work/listings/${idSlug}`} className="w-100 h-100">
     <Card tag={Fade} className="w-100 h-100">
       <div className="embed-responsive embed-responsive-4by3">
         <div className="embed-responsive-item">
@@ -25,7 +26,7 @@ const ListingCard = ({
         <CardText>${pricePerNightUsd} per night</CardText>
       </CardFooter>
     </Card>
-  </a>
+  </Link>
 );
 
 export default ListingCard;


### PR DESCRIPTION
## Description
Continuing redesign of search: Link from search results to listing pages.

## How to Test
1. Go to /work/search
2. Enter a search query that results in some listings
3. Verify that listing cards are still well-formatted
4. Click on a listing from search results
5. Expect to go to /work/listings/:id

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Still need to complete styling of the listing page, and provide a booking flow
