### PR TITLE
fix trips to listing link

### DIFF
--- a/src/components/routes/Trips/ActiveTripCard.tsx
+++ b/src/components/routes/Trips/ActiveTripCard.tsx
@@ -26,7 +26,7 @@ const ActiveTripCard = ({ onCancelClick, trip }: Props) => {
   const { checkInDate, checkOutDate, id, listing, status } = trip;
   const { addressLine1, addressLine2, city, country, lat, lng, postalCode, state } = listing;
   const displayStatus = getUserBookingDisplayStatus(status);
-  const titleLink = status === 'started' ? `/bookings/${id}/options` : `listings/${listing.idSlug}`;
+  const titleLink = status === 'started' ? `/bookings/${id}/options` : `/listings/${listing.idSlug}`;
   return (
     <ActiveTripCardContainer className="active-trip-card">
       <div className="active-trip-photo">
@@ -34,7 +34,7 @@ const ActiveTripCard = ({ onCancelClick, trip }: Props) => {
       </div>
       <div className="active-trip-info">
         <h3>
-          <BeeLink to={titleLink}>{listing.title}</BeeLink>
+          <BeeLink href={titleLink}>{listing.title}</BeeLink>
         </h3>
         <div className="bee-flex-div" />
         <div className="address">


### PR DESCRIPTION
## Description
Why did you write this code?
On the regular trips page, clicking the title should go to the listing but currently crashes.

## How to Test
- [ ] Visit /trips with a current or upcoming booking
- [ ] Click the title

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

