### PR TITLE
Move map behind date picker

### DIFF
--- a/src/styled/customStyles.scss
+++ b/src/styled/customStyles.scss
@@ -54,11 +54,11 @@ $HEADER-HEIGHT: 4.125rem;
 
 .bee-top {
   top: 4.125rem;
-  z-index: 999; // Behind bootstrap overlays
 }
 
 .bee-search-map {
   height: calc(100vh - 11.25rem);
+  z-index: 0;
 }
 
 // add not-allowed cursor and no transform on disabled items


### PR DESCRIPTION
## Description
Map on search page was covering date range inputs; this changes z-indexing so it does not.

## How to Test
1. Search for some listings
2. Open the date range picker on the search page
3. Verify that control is not blocked by map
4. Scroll down
5. Verify that map disappears *under* header, not over

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
