### PR TITLE
Show Carousel on View Photos

### DIFF
--- a/src/components/shared/Portal/Portal.container.ts
+++ b/src/components/shared/Portal/Portal.container.ts
@@ -10,12 +10,12 @@ const PortalContainer = styled.div`
   opacity: 0;
   position: fixed;
   top: 0;
-  z-index: 101;
+  z-index: 1101;
   width: 100%;
 
 
   .bee-portal--children {
-    z-index: 100;
+    z-index: 1100;
   }
 
 

--- a/src/components/work/CarouselPortal/CarouselPortal.tsx
+++ b/src/components/work/CarouselPortal/CarouselPortal.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import CloseButton from 'components/shared/CloseButton';
+import Portal from 'components/shared/Portal';
+import ListingCarousel from 'components/routes/Listing/Listing/ListingCarousel';
+import ListingCarouselPortalContainer from 'components/routes/Listing/Listing/ListingCarouselPortal.container';
+
+interface Props {
+  onClose: () => void;
+  photos: string[];
+}
+
+const CarouselPortal = ({ onClose, photos }: Props) => (
+  <Portal color="black" opacity={0.75}>
+    <ListingCarouselPortalContainer>
+      <CloseButton onClose={onClose} />
+      <ListingCarousel photos={photos} />
+    </ListingCarouselPortalContainer>
+  </Portal>
+);
+
+export default CarouselPortal;

--- a/src/components/work/CarouselPortal/index.ts
+++ b/src/components/work/CarouselPortal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CarouselPortal';

--- a/src/pages/listing/ListingGallery.tsx
+++ b/src/pages/listing/ListingGallery.tsx
@@ -2,15 +2,19 @@ import * as React from 'react';
 import { Button, Row } from 'reactstrap';
 
 import ImageGrid from 'shared/ImageGrid';
+import CarouselPortal from 'components/work/CarouselPortal';
 
 import { Listing } from 'networking/listings';
 
-const ListingGallery = ({ listingPicUrl, photos }: Listing) => (
-  <Row className="w-100 height-60vh px-0 mx-0 position-relative">
+const ListingGallery = ({ listingPicUrl, photos }: Listing) => {
+  const [isOpen, setOpen] = React.useState<boolean>(false);
+  return <Row className="w-100 height-60vh px-0 mx-0 position-relative">
     <ImageGrid images={[listingPicUrl, ...photos]} />
-    <Button className="position-absolute bottom-0 right-0 m-4">
+    <Button className="position-absolute bottom-0 right-0 m-4" onClick={() => setOpen(true)}>
       View Photos <span className="fas fa-camera"></span>
     </Button>
-  </Row>
-);
+    {isOpen && <CarouselPortal photos={[listingPicUrl, ...photos]} onClose={() => setOpen(false)} />}
+  </Row>;
+};
+
 export default ListingGallery;


### PR DESCRIPTION
## Description
Implement the View Photos button under the new design, this time using our existing carousel

## How to Test
1. View `/work/listings/:id` for some listing you like
2. Click "View Photos"
3. Expect photo carousel to appear full screen
4. Click X in top-right of photo carousel
5. Expect photo carousel to go away

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
1. Booking Card functionality
2. And oof, this is a reminder that those left/right arrows are mispositioned; will hot fix that separately

## Learnings
After #240, I have a new appreciation for the fine art of giving up and starting over.
