### PR TITLE
Reposition carousel arrows

### DIFF
--- a/src/styled/containers/Carousel.container.ts
+++ b/src/styled/containers/Carousel.container.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { color, typography } from 'styled/utils';
 
 const CarouselContainerMobile = styled.div`
-  width: 320px;
+  width: calc(100vw - 80px);
 
   .carousel-image-wrapper {
     outline: 0;
@@ -223,7 +223,7 @@ const CarouselContainerMobile = styled.div`
     height: auto;
     margin: 0 auto;
     max-height: 204px;
-    max-width: 320px;
+    max-width: calc(100vw - 80px);
     width: auto;
   }
   .slick-slide.slick-loading img {

--- a/src/styled/containers/Carousel.container.ts
+++ b/src/styled/containers/Carousel.container.ts
@@ -73,10 +73,10 @@ const CarouselContainerMobile = styled.div`
     color: #fff;
   }
   .slick-prev {
-    left: -25px;
+    right: calc(100% + 8px);
   }
   [dir='rtl'] .slick-prev {
-    right: -25px;
+    left: calc(100% + 8px);
     left: auto;
   }
   .slick-prev:before {
@@ -87,11 +87,11 @@ const CarouselContainerMobile = styled.div`
     content: '>';
   }
   .slick-next {
-    right: -25px;
+    left: calc(100% + 8px);
   }
   [dir='rtl'] .slick-next {
     right: auto;
-    left: -25px;
+    right: calc(100% + 8px);
   }
   [dir='rtl'] .slick-next:before {
     content: '>';
@@ -269,12 +269,6 @@ const CarouselContainerDesktop = styled(CarouselContainerTablet)`
     .slick-next:before,
     .slick-prev:before {
       font-size: 144px;
-    }
-    .slick-prev {
-      left: -40px;
-    }
-    .slick-next {
-      right: -40px;
     }
   }
 `;


### PR DESCRIPTION
## Description
Arrows on our carousel could be observed to sometimes disappear behind the image or misalign too far to the right, and to bounce around as image size changed. This positions both arrows consistently outside of the carousel photo area.

## How to Test
1. Navigate to a specific `/listings/:id`
2. Click View Photos
3. Click left and right to scroll through photos
4. Expect left/right arrows to remain in place and visible as photo dimensions change

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
