### PR TITLE
add Footer to work routes, make mobile listing page footer disappear

### DIFF
--- a/src/components/work/Footer/Footer.tsx
+++ b/src/components/work/Footer/Footer.tsx
@@ -69,9 +69,10 @@ const socialData = [
   },
 ];
 
-const Footer = () => (
+export const Footer = () => (
   <Switch>
     <Route path="/work/account" component={DetailedFooter} />
+    <Route exact path="/work/listings/:id" component={NoopComponent} />
     <Route exact path="/work" component={DetailedFooter} />
     <Route exact path="/work/about" component={DetailedFooter} />
     <Route exact path="/work/login" component={NoopComponent} />
@@ -80,8 +81,8 @@ const Footer = () => (
   </Switch>
 )
 
-const DetailedFooter = () => (
-  <footer className="pt-md-10">
+export const DetailedFooter = ({ className }: { className: string }) => (
+  <footer className={`pt-md-10${className ? ' ' + className : ''}`}>
     <Container className="space-lg-2 border-bottom">
       <Row className="justify-content-md-between">
         <Col lg="3" className="d-none d-lg-flex mb-4 mb-lg-0">
@@ -159,5 +160,3 @@ const DetailedFooter = () => (
 );
 
 const NoopComponent = () => null;
-
-export default Footer;

--- a/src/components/work/Footer/Footer.tsx
+++ b/src/components/work/Footer/Footer.tsx
@@ -69,10 +69,10 @@ const socialData = [
   },
 ];
 
-export const Footer = () => (
+const Footer = () => (
   <Switch>
     <Route path="/work/account" component={DetailedFooter} />
-    <Route exact path="/work/listings/:id" component={NoopComponent} />
+    <Route exact path="/work/listings/:id" render={() => <DetailedFooter className="d-none d-lg-block" />} />
     <Route exact path="/work" component={DetailedFooter} />
     <Route exact path="/work/about" component={DetailedFooter} />
     <Route exact path="/work/login" component={NoopComponent} />
@@ -81,7 +81,7 @@ export const Footer = () => (
   </Switch>
 )
 
-export const DetailedFooter = ({ className }: { className: string }) => (
+const DetailedFooter = ({ className }: { className: string }) => (
   <footer className={`pt-md-10${className ? ' ' + className : ''}`}>
     <Container className="space-lg-2 border-bottom">
       <Row className="justify-content-md-between">
@@ -160,3 +160,5 @@ export const DetailedFooter = ({ className }: { className: string }) => (
 );
 
 const NoopComponent = () => null;
+
+export default Footer;

--- a/src/components/work/Footer/index.ts
+++ b/src/components/work/Footer/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Footer';
+export * from './Footer';

--- a/src/components/work/Footer/index.ts
+++ b/src/components/work/Footer/index.ts
@@ -1,1 +1,1 @@
-export * from './Footer';
+export { default } from './Footer';

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -18,7 +18,7 @@ import TripsReceipt from './trips/TripsReceipt';
 import AuthenticatedRoute from 'HOCs/AuthenticatedRoute';
 
 import Header from 'components/work/Header';
-import { Footer } from 'components/work/Footer';
+import Footer from 'components/work/Footer';
 
 import '../styled/customStyles.scss';
 

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -18,6 +18,7 @@ import TripsReceipt from './trips/TripsReceipt';
 import AuthenticatedRoute from 'HOCs/AuthenticatedRoute';
 
 import Header from 'components/work/Header';
+import { Footer } from 'components/work/Footer';
 
 import '../styled/customStyles.scss';
 
@@ -40,6 +41,7 @@ const Work = () => (
       <Route exact path="/work" component={Home} />
       <Route path="/work" component={NotFound} />
     </Switch>
+    <Footer />
   </div>
 );
 

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -3,7 +3,6 @@ import { Button, Col, Container, Fade, Jumbotron, Row } from 'reactstrap';
 
 import { affiliations, guestValueProps, HomeUser, hostValueProps, testimonials } from './home.config';
 
-import Footer from 'components/work/Footer';
 import SearchBar from 'components/work/SearchBar';
 import TestimonialCard from 'components/work/TestimonialCard';
 import ValuePropCard from 'components/work/ValuePropCard';
@@ -108,7 +107,6 @@ const Home = () => {
           </Row>
         </Container>
       </Container>
-      <Footer />
     </>
   );
 

--- a/src/pages/listing/Listing.tsx
+++ b/src/pages/listing/Listing.tsx
@@ -3,7 +3,6 @@ import { Query } from 'react-apollo';
 import { Fade } from 'reactstrap';
 import { GET_PUBLIC_LISTING } from 'networking/listings';
 
-import { DetailedFooter } from 'components/work/Footer';
 import Loading from 'shared/loading/Loading';
 
 import ListingPage from './ListingPage';
@@ -18,7 +17,6 @@ const Listing = ({ match }: RouterProps) => (
         <ListingPage {...data.listing} />
       }
     </Query>
-    <DetailedFooter className="d-none d-lg-block" />
   </Fade>
 );
 

--- a/src/pages/listing/Listing.tsx
+++ b/src/pages/listing/Listing.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { Query } from 'react-apollo';
 import { Fade } from 'reactstrap';
-
-import Footer from 'components/work/Footer';
-
-import Loading from 'shared/loading/Loading';
-
 import { GET_PUBLIC_LISTING } from 'networking/listings';
+
+import { DetailedFooter } from 'components/work/Footer';
+import Loading from 'shared/loading/Loading';
 
 import ListingPage from './ListingPage';
 
@@ -20,7 +18,7 @@ const Listing = ({ match }: RouterProps) => (
         <ListingPage {...data.listing} />
       }
     </Query>
-    <Footer />
+    <DetailedFooter className="d-none d-lg-block" />
   </Fade>
 );
 

--- a/src/pages/listing/ListingPage.tsx
+++ b/src/pages/listing/ListingPage.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Col, Container, Fade, Row } from 'reactstrap';
+import { Listing } from 'networking/listings';
 
 import ListingGallery from './ListingGallery';
 import ListingInformation from './ListingInformation';
 import BookingCard from './BookingCard';
 import BookingBar from './BookingBar';
 
-import { Listing } from 'networking/listings';
 
 const ListingPage = (listing: Listing) => (
   <Fade>

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
 import { Fade } from 'reactstrap';
 import { Query } from 'react-apollo';
-
 import { SEARCH_LISTINGS } from 'networking/listings';
 
-import Footer from 'components/work/Footer';
 import Loading from 'shared/loading/Loading';
-
 import { LISTING_CARD_IMAGE_DIMENSIONS } from 'utils/imageDimensions';
 import { parseQueryString } from 'utils/queryParams';
 
@@ -35,7 +32,6 @@ const Search = () => {
         <SearchPage listings={data.searchListings} />
       }
     </Query>
-    <Footer />
   </Fade>);
 };
 


### PR DESCRIPTION
## Description
Why did you write this code?
Move Footer to pages/work so it renders automatically

## How to Test
- [ ] Visit /work/home, /work/account, /work/trips, /work/search and see Footer
- [ ] Visit /work/listings/:id and see Footer on desktop but no Footer on tablet/mobile

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

