### PR TITLE
Make space above BookingCard

### DIFF
--- a/src/pages/listing/BookingCard.tsx
+++ b/src/pages/listing/BookingCard.tsx
@@ -9,7 +9,7 @@ import { formatPrice } from 'utils/formatter';
 
 const BookingCard = ({
   pricePerNightUsd
-}: Listing) => (<Card className="p-5 m-3 shadow">
+}: Listing) => (<Card className="p-5 shadow">
   <Row className="m-0">
     <h3 className="d-inline">{formatPrice(pricePerNightUsd)}</h3>
     <small className="pl-3 mt-3"> per night</small>

--- a/src/pages/listing/ListingPage.tsx
+++ b/src/pages/listing/ListingPage.tsx
@@ -17,7 +17,7 @@ const ListingPage = (listing: Listing) => (
           <ListingInformation {...listing} />
         </Col>
         <Col>
-          <div className="sticky-top bee-top d-none d-lg-block z-index-0">
+          <div className="sticky-top bee-top d-none d-lg-block z-index-0 p-5">
             <BookingCard {...listing} />
           </div>
         </Col>


### PR DESCRIPTION
## Description
A minor followup to a [review cmment](https://github.com/thebeetoken/beenest-web/pull/253#pullrequestreview-211005195) from #253; make some space between the BookingCard and the header when stickiness kicks in.

## How to Test
1. Visit `/work/listings/:id`
2. Scroll down
3. Expect to see some margin between header and booking card when stickiness kicks in

<img width="482" alt="image" src="https://user-images.githubusercontent.com/42747169/53912863-bf04e680-400e-11e9-9f80-a23b89853bd3.png">

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
...functionality for BookingCard!

