### PR TITLE
Block out reserved dates in BookingCard

### DIFF
--- a/src/pages/listing/BookingCard.tsx
+++ b/src/pages/listing/BookingCard.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import DateRangePicker from 'components/work/DateRangePicker';
 import { guestsSelectboxOptions } from 'components/work/SearchBar/searchBar.config';
 
-import { Listing } from 'networking/listings';
+import { Listing, Reservation } from 'networking/listings';
 import { formatPrice } from 'utils/formatter';
 
 interface Dates {
@@ -14,7 +14,9 @@ interface Dates {
 }
 
 const BookingCard = ({
-  pricePerNightUsd
+  pricePerNightUsd,
+  reservations,
+  totalQuantity
 }: Listing) => {
   const [focusedInput, setFocusedInput] = React.useState<'startDate' | 'endDate' | null>(null);
   const [startDate, setStartDate] = React.useState<moment.Moment | null>(null);
@@ -30,6 +32,7 @@ const BookingCard = ({
     <Row className="w-100 m-0 mb-3">
       <DateRangePicker
         isOutsideRange={() => false}
+        isDayBlocked={isDayBlocked}
         startDate={startDate} // momentPropTypes.momentObj or null,
         startDateId="startDate"
         startDatePlaceholderText="Check-In"
@@ -62,6 +65,24 @@ const BookingCard = ({
       <Button className="w-100">Request to Book</Button>
     </Row>
   </Card>;
+
+  function isDayBlocked(day: moment.Moment) {
+    const quantity = totalQuantity || 1;
+    const utcDay = day.clone().utc().set('hours', 0);
+    const pickingEnd = focusedInput === 'endDate';
+    if (pickingEnd && startDate) {
+      const selectedStartDate = startDate.utc().set('hours', 0);
+      return (
+        utcDay.isBefore(selectedStartDate) ||
+        reservations.filter(({ startDate, endDate }: Reservation) => {
+          return selectedStartDate.isBefore(endDate) && utcDay.isAfter(startDate);
+        }).length >= quantity
+      );
+    }
+    return reservations.filter(({ startDate, endDate }: Reservation) => {
+      return utcDay.isBetween(startDate, endDate, undefined, pickingEnd ? '(]' : '[)');
+    }).length >= quantity;
+  }
 };
 
 export default BookingCard;


### PR DESCRIPTION
## Description
Block out reserved dates in BookingCard

## How to Test
1. Visit `/work/listings/:id` for a listing with known booked dates
  2. Tommy is staying at Actual Nest of Bees (95_vic) from 3/19-3/20, so that was my test case
2. Open the date range picker
3. Verify that start date is unavailable for dates booked (until checkout)
4. Verify that end date is unavailable for dates booked (after checkin)

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
1. Define date range for `isOutsideDateRange`
2. Dynamic pricing
3. Initialize from query parameters
4. Create bookings on Request to Book
5. Show this form when user clicks Request to Book in BookingBar
