### PR TITLE
Specify valid date range in BookingCard

### DIFF
--- a/src/pages/listing/BookingCard.tsx
+++ b/src/pages/listing/BookingCard.tsx
@@ -14,6 +14,8 @@ interface Dates {
 }
 
 const BookingCard = ({
+  checkInDate,
+  checkOutDate,
   pricePerNightUsd,
   reservations,
   totalQuantity
@@ -31,7 +33,7 @@ const BookingCard = ({
     </Row>
     <Row className="w-100 m-0 mb-3">
       <DateRangePicker
-        isOutsideRange={() => false}
+        isOutsideRange={isOutsideDateRange}
         isDayBlocked={isDayBlocked}
         startDate={startDate} // momentPropTypes.momentObj or null,
         startDateId="startDate"
@@ -65,6 +67,15 @@ const BookingCard = ({
       <Button className="w-100">Request to Book</Button>
     </Row>
   </Card>;
+
+  function isOutsideDateRange(day: moment.Moment) {
+    const utcDay = day.clone().utc().set('hours', 0);
+    const firstDay = checkInDate ? moment.utc(checkInDate) :
+      moment().startOf('day').utc().set('hours', 0);
+    const lastDay = checkOutDate ? moment.utc(checkOutDate) :
+      moment().startOf('day').utc().add(6, 'months');
+    return utcDay.isBefore(firstDay) || utcDay.isAfter(lastDay);
+  }
 
   function isDayBlocked(day: moment.Moment) {
     const quantity = totalQuantity || 1;


### PR DESCRIPTION
## Description
Limits the range of dates which can be selected in the date range picker of the booking card

## How to Test
1. Verify dates for a standard listing
  1. Expect yesterday and before to be unavailable
  2. Expect six months from now and later to be unavailable
2. Verify dates for a hotel listing with defined check-in/out dates
  1. Expect only date range defined in the listing to be available

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
1. Dynamic pricing
2. Initialize from query parameters
3. Create bookings on Request to Book
4. BookingBar
