### PR TITLE
Don't pass className where it's not expected

### DIFF
--- a/src/components/work/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/work/DateRangePicker/DateRangePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import omit from 'lodash.omit';
 
 import { DateRangePicker, DateRangePickerShape } from 'react-dates';
 
@@ -10,7 +11,7 @@ interface Props extends DateRangePickerShape {
 
 const WorkDateRangePicker = (props: Props) => (
   <WorkDateRangePickerContainer className={props.className}>
-    <DateRangePicker {...props} />
+    <DateRangePicker {...omit(props, ['className'])} />
   </WorkDateRangePickerContainer>
 );
 


### PR DESCRIPTION
...to avoid console errors on the listing page.

## Description
@kcvan noted console errors on the listing page after a500dea16fc3ccbae59c74a4a78ab3f5f94b0f63; this removes the extraneous prop assignment which was causing those.

## How to Test
1. Visit `/work/listings/:id` for some listing
2. Check your console
3. Expect not to see any "unknown props found" errors

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
None anticipated.

## Learnings
Don't forget to check the console! (I am still going to forget to check the console.)
