### PR TITLE
Remove unused 'component' prop

### DIFF
--- a/src/components/work/SearchBar/SearchBar.tsx
+++ b/src/components/work/SearchBar/SearchBar.tsx
@@ -140,8 +140,7 @@ class SearchBar extends React.Component<RouterProps, State> {
             <Input
               type="select"
               name={NUMBER_OF_GUESTS}
-              onChange={this.handleGuestChange}
-              component="select">
+              onChange={this.handleGuestChange}>
               {guestsSelectboxOptions.map(option => (
                 <option value={option.value} key={option.value}>
                   {option.option}

--- a/src/pages/listing/BookingCard.tsx
+++ b/src/pages/listing/BookingCard.tsx
@@ -84,8 +84,7 @@ const BookingCard = ({
         type="select"
         name="numberOfGuests"
         value={numberOfGuests}
-        onChange={event => setNumberOfGuests(parseInt(event.target.value))}
-        component="select">
+        onChange={event => setNumberOfGuests(parseInt(event.target.value))}>
         {guestsSelectboxOptions.map(option => (
           <option value={option.value} key={option.value}>
             {option.option}


### PR DESCRIPTION
## Description
Sounds like this prop was getting flagged as an error in VSCode? In any event, it is not used and its value is redundant to the "type" property of these inputs.

## How to Test
Regression-test search bar, booking card.

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
