### PR TITLE
Remove Fade from GoogleAutoComplete

### DIFF
--- a/src/components/shared/GoogleAutoComplete/GoogleAutoComplete.tsx
+++ b/src/components/shared/GoogleAutoComplete/GoogleAutoComplete.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Fade } from 'reactstrap';
 import { compose, withProps } from 'recompose';
 import { withScriptjs } from 'react-google-maps';
 
@@ -38,11 +37,7 @@ class GoogleAutoComplete extends React.Component<Props, any> {
   }
 
   render() {
-    return (
-      <Fade>
-        {this.props.children}
-      </Fade>
-    );
+    return this.props.children;
   }
 }
 


### PR DESCRIPTION
## Description
Noticed in the context of #274 that the GoogleAutoComplete input was fading in. The delay was a bit distracting during testing, which reminded me of @tc's [earlier comment](https://github.com/thebeetoken/beenest-web/pull/234#discussion_r262193706) about slowing the user down.

This removes `Fade` from GoogleAutoComplete. You can see an example of the change at `/work` (where, with Fade, the location input fades in *just a bit* slower than the rest of the UI).

Thinking that it makes sense to utilize `Fade` at the level of pages and cards and so on, instead of fine-grained components like form controls; in the latter case, it seems too hard to know if the animation will be appropriate or not.

## How to Test
Regression-test search from the front page (or any other GoogleAutoComplete usages you can think of)

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
