### PR TITLE
remove 'beenest' from signup

### DIFF
--- a/src/pages/signup/SignupForm.tsx
+++ b/src/pages/signup/SignupForm.tsx
@@ -69,7 +69,7 @@ const SignupForm = (props: SignupProps) => {
         <Form tag={FormikForm}>
           <div className="mb-7">
             <h2 className="h3 text-primary font-weight-normal mb-0">
-              Welcome to <span className="font-weight-semi-bold">Beenest</span>
+              Welcome
             </h2>
             <p>Signup to start using Beenest.</p>
           </div>


### PR DESCRIPTION
## Description
Why did you write this code?
remove 'beenest' from signup
## How to Test
- [ ] Visit /signup
- [ ] Verify title only says `Welcome` in blue

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android
