### PR TITLE
Show marker at 'Close To...' location

### DIFF
--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -62,6 +62,15 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
         ref={this.handleMapMounted}
       >
         {near && <Marker
+          icon={{
+            fillColor: '#AADBFF',
+            fillOpacity: 1,
+            labelOrigin: { x: 0, y: -5 },
+            scale: 4,
+            strokeColor: '#1164FF',
+            path: google.maps.SymbolPath.CIRCLE,
+            strokeWeight: 2
+          }}
           label={near.name}
           position={near.geometry.location}
           title={near.name}

--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -17,6 +17,7 @@ interface Props extends RouterProps {
   className?: string;
   height?: string;
   listings: ListingShort[];
+  near?: google.maps.places.PlaceResult;
   width?: string;
 }
 
@@ -52,7 +53,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
   }
 
   render() {
-    const { listings } = this.props;
+    const { listings, near } = this.props;
     const { selectedListing } = this.state;
     return (
       <GoogleMap
@@ -60,6 +61,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
         defaultCenter={getCenterCoordinates(listings)}
         ref={this.handleMapMounted}
       >
+        {near && <Marker position={near.geometry.location} />}
         {listings.map(listing => (
           <Marker key={listing.id}
             position={{ lat: listing.lat, lng: listing.lng }}

--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -61,7 +61,11 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
         defaultCenter={getCenterCoordinates(listings)}
         ref={this.handleMapMounted}
       >
-        {near && <Marker position={near.geometry.location} />}
+        {near && <Marker
+          label={near.name}
+          position={near.geometry.location}
+          title={near.name}
+        />}
         {listings.map(listing => (
           <Marker key={listing.id}
             position={{ lat: listing.lat, lng: listing.lng }}

--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -78,6 +78,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
           }}
           position={near.geometry.location}
           title={near.name}
+          zIndex={1000}
         />}
         {listings.map(listing => (
           <Marker key={listing.id}

--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -71,7 +71,11 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
             path: google.maps.SymbolPath.CIRCLE,
             strokeWeight: 2
           }}
-          label={near.name}
+          label={{
+            color: '#333',
+            fontSize: '1rem',
+            text: near.name
+          }}
           position={near.geometry.location}
           title={near.name}
         />}

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -16,7 +16,7 @@ interface Props {
   checkOutDate?: string;
   numberOfGuests?: number;
   onFilterChange?: (filter: SearchFilterCriteria) => void;
-  filter?: SearchFilterCriteria;
+  filter: SearchFilterCriteria;
   listings: Listing[];
 }
 
@@ -35,7 +35,11 @@ const SearchPage = (props: Props) => <Fade>
     </Col>
     <Col md="0" lg="7" xl="8" className="px-0 d-md-none d-lg-block">
       <div className="w-100 sticky-top bee-top bee-search-map z-index-0">
-        <GoogleMapsWithMarkers className="w-100 h-100" listings={props.listings} />
+        <GoogleMapsWithMarkers
+          className="w-100 h-100"
+          listings={props.listings}
+          near={props.filter.near}
+        />
       </div>
     </Col>
   </Row>


### PR DESCRIPTION
## Description
Continuing with search filters: Show a marker at the user's chosen 'Close To...' location

## How to Test
1. Search
2. Click 'Close To...'
3. Select some place on your map
4. Verify that labelled marker shows up at that place

Which devices did you test on?
- [ ] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
1. Driving directions
2. Centering on pin
3. More filters

## Learnings
Looked at the "centering on pin" part, think that needs to be its own issue; correct behavior is non-obvious, as other variables including the search query's bounds and the locations of listings themselves need to be considered

