### PR TITLE
Fix Header not closing on mobile

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, withRouter } from 'react-router-dom';
 
 import ApolloWrapper from 'HOCs/ApolloWrapper';
 import ErrorBoundaryWrapper from 'HOCs/ErrorBoundaryWrapper';
@@ -17,13 +17,29 @@ if (APP_ENV === AppEnv.PRODUCTION) {
 import App from './pages';
 import '../src/styled/customStyles.scss';
 
+class ScrollToTop extends React.Component<RouterProps, {}> {
+  componentDidUpdate(prevProps: RouterProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+const ScrollToTopWithRouter = withRouter(ScrollToTop);
+
 ReactDOM.render(
   <>
     <ErrorBoundaryWrapper>
       <ApolloWrapper>
         <FirebaseProvider>
           <BrowserRouter>
-            <App />
+            <ScrollToTopWithRouter>
+              <App />
+            </ScrollToTopWithRouter>
           </BrowserRouter>
         </FirebaseProvider>
       </ApolloWrapper>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { BrowserRouter, withRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import ApolloWrapper from 'HOCs/ApolloWrapper';
 import ErrorBoundaryWrapper from 'HOCs/ErrorBoundaryWrapper';
@@ -17,29 +17,13 @@ if (APP_ENV === AppEnv.PRODUCTION) {
 import App from './pages';
 import '../src/styled/customStyles.scss';
 
-class ScrollToTop extends React.Component<RouterProps, {}> {
-  componentDidUpdate(prevProps: RouterProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
-      window.scrollTo(0, 0);
-    }
-  }
-
-  render() {
-    return this.props.children;
-  }
-}
-
-const ScrollToTopWithRouter = withRouter(ScrollToTop);
-
 ReactDOM.render(
   <>
     <ErrorBoundaryWrapper>
       <ApolloWrapper>
         <FirebaseProvider>
           <BrowserRouter>
-            <ScrollToTopWithRouter>
-              <App />
-            </ScrollToTopWithRouter>
+            <App />
           </BrowserRouter>
         </FirebaseProvider>
       </ApolloWrapper>

--- a/src/legacy/work/Header/Header.tsx
+++ b/src/legacy/work/Header/Header.tsx
@@ -90,12 +90,17 @@ const DetailedHeader = () => {
                         const isHost = beeUser.listingCount > 0;
                         return (
                           <>
-                            <Link to={isHost ? HOST_PORTAL_LINK : HOST_INTEREST_LINK} className="mb-4 mb-md-0 mr-md-4 w-100 w-md-auto btn btn-outline-primary">
+                            <Link
+                              to={isHost ? HOST_PORTAL_LINK : HOST_INTEREST_LINK}
+                              className="mb-4 mb-md-0 mr-md-4 w-100 w-md-auto btn btn-outline-primary">
                               {isHost ? 'Host Profile' : 'Become a Host'}
                             </Link>
                             {authNavItems.map(item => (
                               <NavItem className="px-2" key={item.header}>
-                                <NavLink to={item.link} tag={Link}>
+                                <NavLink
+                                  onClick={() => toggleNavbar(false)}
+                                  tag={Link}
+                                  to={item.link}>
                                   {item.header}
                                 </NavLink>
                               </NavItem>
@@ -113,7 +118,10 @@ const DetailedHeader = () => {
                     </Link>
                     {navItems.map(item => (
                       <NavItem className="px-2" key={item.header}>
-                        <NavLink to={item.link} tag={Link}>
+                        <NavLink
+                          onClick={() => toggleNavbar(false)}
+                          tag={Link}
+                          to={item.link}>
                           {item.header}
                         </NavLink>
                       </NavItem>


### PR DESCRIPTION
## Description
Why did you write this code?
header doesn't close its menu on mobile when nav is clicked

This works for now. Could use some refactoring -- can follow up with a refactor PR to split components up (data fetching vs displaying info, making separate mobile and desktop navs, etc.)

## How to Test
- [ ] Visit '/' on Mobile Screensize
- [ ] Click collapsed menu button
- [ ] Click 'Trips' or 'Account'
- [ ] Verify the menu closes

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

