### PR TITLE
Ignore place changes without geometry

### DIFF
--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -13,7 +13,7 @@ const TransitTime = ({ place, onPlaceChange }: Props) => {
 
   const handlePlace = (place: google.maps.places.PlaceResult) => {
     if (onPlaceChange) {
-      onPlaceChange(place);
+      onPlaceChange(place && place.geometry ? place : null);
     }
   };
   const handleClear = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {


### PR DESCRIPTION
## Description
Prevents a page crash when user clicks enter in the "Close To..." autocomplete input, instead of selecting from the list.

## How to Test
1. Search for some listings
2. Click "Close To..." to open the filter's dropdown menu
3. Type in some text
4. Click enter (without pressing down to go into autocomplete results)
5. Expect application not to crash (and to remain in a useful/sensible state)

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
This is a fix to a crash, but may not be a complete solution to UX issues here. Simply doing nothing when the user presses enter from the autocomplete isn't particularly clear or instructive

## Learnings
Google's Autocomplete API is fairly narrow and doesn't provide the information needed to support "select the user's top result". The only distinction between user-entered text and user-selected option is the presence of [`geometry` and other properties](https://developers.google.com/maps/documentation/javascript/reference/places-widget#Autocomplete.getPlace). We could manually make a geocoder call with the same text and get results that way, but that sounds like the level of complexity we're trying to avoid at this point

