### PR TITLE
Make search filter full width

### DIFF
--- a/src/pages/search/SearchFilter.tsx
+++ b/src/pages/search/SearchFilter.tsx
@@ -13,7 +13,7 @@ const SearchFilter = ({ children, label }: Props) => {
       <DropdownToggle>
         {label}
       </DropdownToggle>
-      <DropdownMenu>
+      <DropdownMenu className="w-100">
         {children}
       </DropdownMenu>
     </Dropdown>


### PR DESCRIPTION
## Description
To reduce likelihood of place names being cut off, make the dropdown for a search filter the full width of its parents.

## How to Test
1. Search
2. Click "Close To..."
3. Expect dropdown to use full width (sans margin/padding) of its containing element

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
