### PR TITLE
Add travel mode selection

### DIFF
--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -59,7 +59,11 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (['near', 'selectedListing', 'travelMode'].every(key => prevProps[key] === this.props[key])) {
+    if (
+      prevProps.near === this.props.near &&
+      prevProps.selectedListing === this.props.selectedListing &&
+      prevProps.travelMode === this.props.travelMode
+    ) {
       return;
     }
     const { near, selectedListing, travelMode } = this.props;

--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -59,10 +59,10 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { near, selectedListing, travelMode } = this.props;
-    if (near === prevProps.near && selectedListing === prevProps.selectedListing) {
+    if (['near', 'selectedListing', 'travelMode'].every(key => prevProps[key] === this.props[key])) {
       return;
     }
+    const { near, selectedListing, travelMode } = this.props;
     if (selectedListing && near) {
       const directionsService = new google.maps.DirectionsService();
       directionsService.route({

--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -22,6 +22,7 @@ interface Props extends RouterProps {
   selectedListing?: ListingShort;
   listings: ListingShort[];
   near?: google.maps.places.PlaceResult;
+  travelMode?: string;
   width?: string;
   onSelect: (listing: ListingShort | null) => void;
 }
@@ -58,7 +59,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { near, selectedListing } = this.props;
+    const { near, selectedListing, travelMode } = this.props;
     if (near === prevProps.near && selectedListing === prevProps.selectedListing) {
       return;
     }
@@ -67,7 +68,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
       directionsService.route({
         origin: { lat: selectedListing.lat, lng: selectedListing.lng },
         destination: near.geometry.location,
-        travelMode: google.maps.TravelMode.DRIVING
+        travelMode: travelMode || google.maps.TravelMode.DRIVING
       }, (directions, status) => {
         if (status === google.maps.DirectionsStatus.OK) {
           this.setState({ directions });

--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -22,7 +22,7 @@ interface Props extends RouterProps {
   selectedListing?: ListingShort;
   listings: ListingShort[];
   near?: google.maps.places.PlaceResult;
-  travelMode?: string;
+  travelMode?: google.maps.TravelMode;
   width?: string;
   onSelect: (listing: ListingShort | null) => void;
 }

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -26,8 +26,12 @@ const SEARCH_PARAMS = [
   'numberOfGuests'
 ];
 
+const DEFAULT_SEARCH_FILTER: SearchFilterCriteria = {
+  travelMode: 'DRIVING'
+};
+
 const Search = () => {
-  const [filter, setFilter] = React.useState<SearchFilterCriteria>({});
+  const [filter, setFilter] = React.useState<SearchFilterCriteria>(DEFAULT_SEARCH_FILTER);
   const queryParams: any = parseQueryString(location.search);
   const queryInput: any = SEARCH_PARAMS.reduce(
     (obj, param) => queryParams[param] ? { ...obj, [param]: queryParams[param] } : obj,

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -26,12 +26,10 @@ const SEARCH_PARAMS = [
   'numberOfGuests'
 ];
 
-const DEFAULT_SEARCH_FILTER: SearchFilterCriteria = {
-  travelMode: 'DRIVING'
-};
-
 const Search = () => {
-  const [filter, setFilter] = React.useState<SearchFilterCriteria>(DEFAULT_SEARCH_FILTER);
+  const [filter, setFilter] = React.useState<SearchFilterCriteria>({
+    travelMode: typeof google !== 'undefined' ? google.maps.TravelMode.DRIVING : undefined
+  });
   const queryParams: any = parseQueryString(location.search);
   const queryInput: any = SEARCH_PARAMS.reduce(
     (obj, param) => queryParams[param] ? { ...obj, [param]: queryParams[param] } : obj,

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -1,7 +1,7 @@
 import { ListingSearchInput } from 'networking/listings';
 
 export interface SearchFilterCriteria {
-  travelMode: string;
+  travelMode?: google.maps.TravelMode;
   near?: google.maps.places.PlaceResult;
 }
 

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -1,6 +1,7 @@
 import { ListingSearchInput } from 'networking/listings';
 
 export interface SearchFilterCriteria {
+  travelMode: string;
   near?: google.maps.places.PlaceResult;
 }
 

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -6,8 +6,8 @@ import TransitTime from './filters/TransitTime';
 import SearchFilter from './SearchFilter';
 
 interface Props {
-  filter?: SearchFilterCriteria;
-  onFilterChange?: (filter: SearchFilterCriteria) => void;
+  filter: SearchFilterCriteria;
+  onFilterChange: (filter: SearchFilterCriteria) => void;
 }
 
 const SearchForm = ({ filter, onFilterChange }: Props) => {
@@ -16,8 +16,8 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
       <Col>
         <SearchFilter label="Close To...">
           <TransitTime
-            place={filter ? filter.near : undefined}
-            travelMode={filter ? filter.travelMode : 'DRIVING'}
+            place={filter.near}
+            travelMode={filter.travelMode}
             onPlaceChange={handlePlaceChange}
             onTravelModeChange={handleTravelModeChange}
           />
@@ -38,7 +38,7 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
     }
   }
 
-  function handleTravelModeChange(travelMode: string) {
+  function handleTravelModeChange(travelMode: google.maps.TravelMode) {
     if (onFilterChange && filter) {
       onFilterChange({ ...filter, travelMode });
     }

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -17,7 +17,9 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
         <SearchFilter label="Close To...">
           <TransitTime
             place={filter ? filter.near : undefined}
+            travelMode={filter ? filter.travelMode : 'DRIVING'}
             onPlaceChange={handlePlaceChange}
+            onTravelModeChange={handleTravelModeChange}
           />
         </SearchFilter>
       </Col>
@@ -25,8 +27,20 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
   </Container>;
 
   function handlePlaceChange(place: google.maps.places.PlaceResult | null) {
-    if (onFilterChange) {
-      onFilterChange(place ? { near: place } : {});
+    if (onFilterChange && filter) {
+      const nextFilter: SearchFilterCriteria = { ...filter };
+      if (!place) {
+        delete nextFilter.near;
+      } else {
+        nextFilter.near = place;
+      }
+      onFilterChange(nextFilter);
+    }
+  }
+
+  function handleTravelModeChange(travelMode: string) {
+    if (onFilterChange && filter) {
+      onFilterChange({ ...filter, travelMode });
     }
   }
 };

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -16,7 +16,7 @@ interface Props {
   checkInDate?: string;
   checkOutDate?: string;
   numberOfGuests?: number;
-  onFilterChange?: (filter: SearchFilterCriteria) => void;
+  onFilterChange: (filter: SearchFilterCriteria) => void;
   filter: SearchFilterCriteria;
   listings: Listing[];
 }

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -56,6 +56,7 @@ const SearchPage = ({
             className="w-100 h-100"
             listings={listings}
             near={filter.near}
+            travelMode={filter.travelMode}
             selectedListing={debouncedListing || undefined}
             onSelect={selectListing}
           />

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { Container, Input } from 'reactstrap';
+import { Col, Container, Input, Row } from 'reactstrap';
 
 import GoogleAutoComplete from 'components/shared/GoogleAutoComplete';
+
+const TRAVEL_MODES = [ 'Driving', 'Transit', 'Walking', 'Bicycling' ];
 
 interface Props {
   place?: google.maps.places.PlaceResult;
@@ -46,6 +48,13 @@ const TransitTime = ({ place, onPlaceChange }: Props) => {
         defaultValue={place ? place.name : ''}
         required />
     </GoogleAutoComplete>
+    <h6 className="mt-3">Travel Mode</h6>
+    <Row tag="form" className="form-check form-check-inline">
+      {TRAVEL_MODES.map(mode => <Col xs="6" key={mode}>
+        <Input className="form-check-input" id={mode.toLowerCase()} type="radio" name="travelMode" value={mode.toUpperCase()} />
+        <label className="form-check-label" htmlFor={mode.toLowerCase()}>{mode}</label>
+      </Col>)}
+    </Row>
   </Container>;
 }
 

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -8,11 +8,11 @@ const TRAVEL_MODES = [ 'Driving', 'Transit', 'Walking', 'Bicycling' ];
 interface Props {
   place?: google.maps.places.PlaceResult;
   onPlaceChange?: (place: google.maps.places.PlaceResult | null) => void;
-  onTravelModeChange?: (travelMode: string) => void;
+  onTravelModeChange: (travelMode: string) => void;
   travelMode: string;
 }
 
-const TransitTime = ({ place, onPlaceChange, travelMode }: Props) => {
+const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: Props) => {
   const inputRef: React.RefObject<HTMLInputElement | null> = React.createRef();
 
   const handlePlace = (place: google.maps.places.PlaceResult) => {
@@ -60,6 +60,7 @@ const TransitTime = ({ place, onPlaceChange, travelMode }: Props) => {
           name="travelMode"
           value={mode.toUpperCase()}
           checked={mode.toUpperCase() === travelMode}
+          onChange={() => onTravelModeChange(mode.toUpperCase())}
         />
         <label className="form-check-label" htmlFor={mode.toLowerCase()}>{mode}</label>
       </Col>)}

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -17,6 +17,7 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
     'Walking': google.maps.TravelMode.WALKING,
     'Cycling': google.maps.TravelMode.BICYCLING
   } : {};
+  const selectedMode = travelMode || google.maps.TravelMode.DRIVING;
 
   const inputRef: React.RefObject<HTMLInputElement | null> = React.createRef();
 
@@ -69,7 +70,7 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
           type="radio"
           name="travelMode"
           value={mode}
-          checked={mode === travelMode}
+          checked={mode === selectedMode}
           onChange={() => mode && handleTravelMode(mode)}
         />
         <label className="form-check-label" htmlFor={name.toLowerCase()}>{name}</label>

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -17,7 +17,6 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
     'Walking': google.maps.TravelMode.WALKING,
     'Cycling': google.maps.TravelMode.BICYCLING
   } : {};
-  const selectedMode = travelMode || google.maps.TravelMode.DRIVING;
 
   const inputRef: React.RefObject<HTMLInputElement | null> = React.createRef();
 
@@ -63,14 +62,14 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
     </GoogleAutoComplete>
     <h6 className="mt-3">Travel Mode</h6>
     <Row tag="form" className="form-check form-check-inline">
-      {Object.entries(travelModes).map(([name, mode]) => <Col xs="6" key={mode}>
+      {Object.entries(travelModes).map(([name, mode], index) => <Col xs="6" key={mode}>
         <Input
           className="form-check-input"
           id={name.toLowerCase()}
           type="radio"
           name="travelMode"
           value={mode}
-          checked={mode === selectedMode}
+          checked={(mode === travelMode) || (!travelMode && index === 0)}
           onChange={() => mode && handleTravelMode(mode)}
         />
         <label className="form-check-label" htmlFor={name.toLowerCase()}>{name}</label>

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -8,9 +8,11 @@ const TRAVEL_MODES = [ 'Driving', 'Transit', 'Walking', 'Bicycling' ];
 interface Props {
   place?: google.maps.places.PlaceResult;
   onPlaceChange?: (place: google.maps.places.PlaceResult | null) => void;
+  onTravelModeChange?: (travelMode: string) => void;
+  travelMode: string;
 }
 
-const TransitTime = ({ place, onPlaceChange }: Props) => {
+const TransitTime = ({ place, onPlaceChange, travelMode }: Props) => {
   const inputRef: React.RefObject<HTMLInputElement | null> = React.createRef();
 
   const handlePlace = (place: google.maps.places.PlaceResult) => {
@@ -51,7 +53,14 @@ const TransitTime = ({ place, onPlaceChange }: Props) => {
     <h6 className="mt-3">Travel Mode</h6>
     <Row tag="form" className="form-check form-check-inline">
       {TRAVEL_MODES.map(mode => <Col xs="6" key={mode}>
-        <Input className="form-check-input" id={mode.toLowerCase()} type="radio" name="travelMode" value={mode.toUpperCase()} />
+        <Input
+          className="form-check-input"
+          id={mode.toLowerCase()}
+          type="radio"
+          name="travelMode"
+          value={mode.toUpperCase()}
+          checked={mode.toUpperCase() === travelMode}
+        />
         <label className="form-check-label" htmlFor={mode.toLowerCase()}>{mode}</label>
       </Col>)}
     </Row>

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -3,16 +3,21 @@ import { Col, Container, Input, Row } from 'reactstrap';
 
 import GoogleAutoComplete from 'components/shared/GoogleAutoComplete';
 
-const TRAVEL_MODES = [ 'Driving', 'Transit', 'Walking', 'Bicycling' ];
-
 interface Props {
   place?: google.maps.places.PlaceResult;
   onPlaceChange?: (place: google.maps.places.PlaceResult | null) => void;
-  onTravelModeChange: (travelMode: string) => void;
-  travelMode: string;
+  onTravelModeChange?: (travelMode: google.maps.TravelMode) => void;
+  travelMode?: google.maps.TravelMode;
 }
 
 const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: Props) => {
+  const travelModes = typeof google !== 'undefined' ? {
+    'Driving': google.maps.TravelMode.DRIVING,
+    'Transit': google.maps.TravelMode.TRANSIT,
+    'Walking': google.maps.TravelMode.WALKING,
+    'Cycling': google.maps.TravelMode.BICYCLING
+  } : {};
+
   const inputRef: React.RefObject<HTMLInputElement | null> = React.createRef();
 
   const handlePlace = (place: google.maps.places.PlaceResult) => {
@@ -27,6 +32,11 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
     }
     if (onPlaceChange) {
       onPlaceChange(null);
+    }
+  };
+  const handleTravelMode = (mode: google.maps.TravelMode) => {
+    if (onTravelModeChange) {
+      onTravelModeChange(mode);
     }
   };
 
@@ -52,17 +62,17 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
     </GoogleAutoComplete>
     <h6 className="mt-3">Travel Mode</h6>
     <Row tag="form" className="form-check form-check-inline">
-      {TRAVEL_MODES.map(mode => <Col xs="6" key={mode}>
+      {Object.entries(travelModes).map(([name, mode]) => <Col xs="6" key={mode}>
         <Input
           className="form-check-input"
-          id={mode.toLowerCase()}
+          id={name.toLowerCase()}
           type="radio"
           name="travelMode"
-          value={mode.toUpperCase()}
-          checked={mode.toUpperCase() === travelMode}
-          onChange={() => onTravelModeChange(mode.toUpperCase())}
+          value={mode}
+          checked={mode === travelMode}
+          onChange={() => mode && handleTravelMode(mode)}
         />
-        <label className="form-check-label" htmlFor={mode.toLowerCase()}>{mode}</label>
+        <label className="form-check-label" htmlFor={name.toLowerCase()}>{name}</label>
       </Col>)}
     </Row>
   </Container>;


### PR DESCRIPTION
## Description
This adds the ability to choose travel mode (from driving, transit, walking, and bicycling) when selecting a "Close To..." location

## How to Test
1. Make a search
2. Enter a "Close To..." location
3. Hover over some listings to view directions
4. Use "Close To..." drop down to change travel mode (e.g. to "walking")
5. Hover over more listings
6. Expect directions to change to fit the specified travel mode

Note that sometimes the visual difference between (e.g.) driving directions and walking can be subtle.

Which devices did you test on?
- [ ] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
The full-page-reload which occurs on some destination changes becomes a bit more painful with this change, as it prevents the user from directly proceeding to selecting travel mode
