### PR TITLE
Add Home Type filter

### DIFF
--- a/src/networking/listings.ts
+++ b/src/networking/listings.ts
@@ -61,6 +61,7 @@ export interface Listing {
 export interface ListingSearchInput {
   checkInDate?: string;
   checkOutDate?: string;
+  homeType?: string;
   numberOfGuests?: number;
   locationQuery?: string;
   bounds?: LatLngBounds;

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -1,13 +1,17 @@
 import { ListingSearchInput } from 'networking/listings';
 
 export interface SearchFilterCriteria {
+  homeType?: string;
   travelMode?: google.maps.TravelMode;
   near?: google.maps.places.PlaceResult;
 }
 
-export function toListingSearchInput(filter : SearchFilterCriteria): ListingSearchInput {
-  return filter.near ? { near: {
-    lat: filter.near.geometry.location.lat(),
-    lng: filter.near.geometry.location.lng() }
-  } : {};
+export function toListingSearchInput({ near, homeType }: SearchFilterCriteria): ListingSearchInput {
+  return {
+    near: near && {
+      lat: near.geometry.location.lat(),
+      lng: near.geometry.location.lng()
+    },
+    homeType
+  };
 }

--- a/src/pages/search/SearchFilter.tsx
+++ b/src/pages/search/SearchFilter.tsx
@@ -9,11 +9,11 @@ interface Props {
 const SearchFilter = ({ children, label }: Props) => {
   const [isOpen, setOpen] = React.useState<boolean>(false);
   return (
-    <Dropdown isOpen={isOpen} toggle={() => setOpen(!isOpen)}>
-      <DropdownToggle outline>
+    <Dropdown group isOpen={isOpen} toggle={() => setOpen(!isOpen)}>
+      <DropdownToggle outline className="btn-sm">
         {label}
       </DropdownToggle>
-      <DropdownMenu className="w-100">
+      <DropdownMenu className="bee-search-menu">
         {children}
       </DropdownMenu>
     </Dropdown>

--- a/src/pages/search/SearchFilter.tsx
+++ b/src/pages/search/SearchFilter.tsx
@@ -3,17 +3,18 @@ import { Dropdown, DropdownToggle, DropdownMenu } from 'reactstrap';
 
 interface Props {
   children: React.ReactNode;
-  label: String;
+  label: string;
+  menuClassName?: string;
 }
 
-const SearchFilter = ({ children, label }: Props) => {
+const SearchFilter = ({ children, label, menuClassName }: Props) => {
   const [isOpen, setOpen] = React.useState<boolean>(false);
   return (
     <Dropdown group isOpen={isOpen} toggle={() => setOpen(!isOpen)}>
       <DropdownToggle outline className="btn-sm">
         {label}
       </DropdownToggle>
-      <DropdownMenu className="bee-search-menu">
+      <DropdownMenu className={menuClassName}>
         {children}
       </DropdownMenu>
     </Dropdown>

--- a/src/pages/search/SearchFilter.tsx
+++ b/src/pages/search/SearchFilter.tsx
@@ -4,17 +4,17 @@ import { Dropdown, DropdownToggle, DropdownMenu } from 'reactstrap';
 interface Props {
   children: React.ReactNode;
   label: string;
-  menuClassName?: string;
+  width?: string;
 }
 
-const SearchFilter = ({ children, label, menuClassName }: Props) => {
+const SearchFilter = ({ children, label, width }: Props) => {
   const [isOpen, setOpen] = React.useState<boolean>(false);
   return (
     <Dropdown group isOpen={isOpen} toggle={() => setOpen(!isOpen)}>
       <DropdownToggle outline className="btn-sm">
         {label}
       </DropdownToggle>
-      <DropdownMenu className={menuClassName}>
+      <DropdownMenu style={{ width }}>
         {children}
       </DropdownMenu>
     </Dropdown>

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -15,13 +15,13 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
   return <Container>
     <Row>
       <ButtonGroup>
-        <SearchFilter label="Home Type" menuClassName="bee-search-menu-narrow">
+        <SearchFilter label="Home Type" width="9rem">
           <HomeType
             homeType={filter.homeType}
             onChange={homeType => console.log(homeType)}
           />
         </SearchFilter>
-        <SearchFilter label="Destination" menuClassName="bee-search-menu-wide">
+        <SearchFilter label="Destination" width="24rem">
           <TransitTime
             place={filter.near}
             travelMode={filter.travelMode}

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const SearchForm = ({ filter, onFilterChange }: Props) => {
   return <Container>
-    <Row>
+    <Row noGutters>
       <ButtonGroup>
         <SearchFilter label="Home Type" width="9rem">
           <HomeType

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -34,27 +34,21 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
   </Container>;
 
   function handlePlaceChange(place: google.maps.places.PlaceResult | null) {
-    if (onFilterChange && filter) {
-      const nextFilter: SearchFilterCriteria = { ...filter };
-      if (!place) {
-        delete nextFilter.near;
-      } else {
-        nextFilter.near = place;
-      }
-      onFilterChange(nextFilter);
+    const nextFilter: SearchFilterCriteria = { ...filter };
+    if (!place) {
+      delete nextFilter.near;
+    } else {
+      nextFilter.near = place;
     }
+    onFilterChange(nextFilter);
   }
 
   function handleTravelModeChange(travelMode: google.maps.TravelMode) {
-    if (onFilterChange && filter) {
-      onFilterChange({ ...filter, travelMode });
-    }
+    onFilterChange({ ...filter, travelMode });
   }
 
   function handleHomeTypeChange(homeType: string) {
-    if (onFilterChange && filter) {
-      onFilterChange({ ...filter, homeType });
-    }
+    onFilterChange({ ...filter, homeType });
   }
 };
 

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Col, Container, Row } from 'reactstrap';
+import { ButtonGroup, Container, Row } from 'reactstrap';
 
 import { SearchFilterCriteria } from './SearchCriteria';
 import HomeType from './filters/HomeType';
@@ -14,16 +14,14 @@ interface Props {
 const SearchForm = ({ filter, onFilterChange }: Props) => {
   return <Container>
     <Row>
-      <Col>
+      <ButtonGroup>
         <SearchFilter label="Home Type">
           <HomeType
             homeType={filter.homeType}
             onChange={homeType => console.log(homeType)}
           />
         </SearchFilter>
-      </Col>
-      <Col>
-        <SearchFilter label="Add Destination">
+        <SearchFilter label="Destination">
           <TransitTime
             place={filter.near}
             travelMode={filter.travelMode}
@@ -31,7 +29,7 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
             onTravelModeChange={handleTravelModeChange}
           />
         </SearchFilter>
-      </Col>
+      </ButtonGroup>
     </Row>
   </Container>;
 

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -15,13 +15,13 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
   return <Container>
     <Row>
       <ButtonGroup>
-        <SearchFilter label="Home Type">
+        <SearchFilter label="Home Type" menuClassName="bee-search-menu-narrow">
           <HomeType
             homeType={filter.homeType}
             onChange={homeType => console.log(homeType)}
           />
         </SearchFilter>
-        <SearchFilter label="Destination">
+        <SearchFilter label="Destination" menuClassName="bee-search-menu-wide">
           <TransitTime
             place={filter.near}
             travelMode={filter.travelMode}

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -18,7 +18,7 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
         <SearchFilter label="Home Type" width="9rem">
           <HomeType
             homeType={filter.homeType}
-            onChange={homeType => console.log(homeType)}
+            onChange={handleHomeTypeChange}
           />
         </SearchFilter>
         <SearchFilter label="Destination" width="24rem">
@@ -48,6 +48,12 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
   function handleTravelModeChange(travelMode: google.maps.TravelMode) {
     if (onFilterChange && filter) {
       onFilterChange({ ...filter, travelMode });
+    }
+  }
+
+  function handleHomeTypeChange(homeType: string) {
+    if (onFilterChange && filter) {
+      onFilterChange({ ...filter, homeType });
     }
   }
 };

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -18,7 +18,7 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
         <SearchFilter label="Home Type" width="9rem">
           <HomeType
             homeType={filter.homeType}
-            onChange={handleHomeTypeChange}
+            onChange={homeType => onFilterChange({ ...filter, homeType })}
           />
         </SearchFilter>
         <SearchFilter label="Destination" width="24rem">
@@ -45,10 +45,6 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
 
   function handleTravelModeChange(travelMode: google.maps.TravelMode) {
     onFilterChange({ ...filter, travelMode });
-  }
-
-  function handleHomeTypeChange(homeType: string) {
-    onFilterChange({ ...filter, homeType });
   }
 };
 

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Col, Container, Row } from 'reactstrap';
 
 import { SearchFilterCriteria } from './SearchCriteria';
+import HomeType from './filters/HomeType';
 import TransitTime from './filters/TransitTime';
 import SearchFilter from './SearchFilter';
 
@@ -13,6 +14,14 @@ interface Props {
 const SearchForm = ({ filter, onFilterChange }: Props) => {
   return <Container>
     <Row>
+      <Col>
+        <SearchFilter label="Home Type">
+          <HomeType
+            homeType={filter.homeType}
+            onChange={homeType => console.log(homeType)}
+          />
+        </SearchFilter>
+      </Col>
       <Col>
         <SearchFilter label="Add Destination">
           <TransitTime

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -25,23 +25,13 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
           <TransitTime
             place={filter.near}
             travelMode={filter.travelMode}
-            onPlaceChange={handlePlaceChange}
+            onPlaceChange={near => onFilterChange({ ...filter, near })}
             onTravelModeChange={travelMode => onFilterChange({ ...filter, travelMode })}
           />
         </SearchFilter>
       </ButtonGroup>
     </Row>
   </Container>;
-
-  function handlePlaceChange(place: google.maps.places.PlaceResult | null) {
-    const nextFilter: SearchFilterCriteria = { ...filter };
-    if (!place) {
-      delete nextFilter.near;
-    } else {
-      nextFilter.near = place;
-    }
-    onFilterChange(nextFilter);
-  }
 };
 
 export default SearchForm;

--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -26,7 +26,7 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
             place={filter.near}
             travelMode={filter.travelMode}
             onPlaceChange={handlePlaceChange}
-            onTravelModeChange={handleTravelModeChange}
+            onTravelModeChange={travelMode => onFilterChange({ ...filter, travelMode })}
           />
         </SearchFilter>
       </ButtonGroup>
@@ -41,10 +41,6 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
       nextFilter.near = place;
     }
     onFilterChange(nextFilter);
-  }
-
-  function handleTravelModeChange(travelMode: google.maps.TravelMode) {
-    onFilterChange({ ...filter, travelMode });
   }
 };
 

--- a/src/pages/search/filters/HomeType.tsx
+++ b/src/pages/search/filters/HomeType.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import { Container, Input } from 'reactstrap';
+import { Col, Container, Input, Row } from 'reactstrap';
 
 import { HomeTypeAdminForm } from 'utils/validators';
 
-const ANY_HOME = 'Any Home Type';
 const HOME_TYPES = [
-  { name: 'Any', value: ANY_HOME },
+  { name: 'Any', value: undefined },
   ...(Object.values(HomeTypeAdminForm).map(
     value => ({ name: value, value })
   ))
@@ -16,22 +15,21 @@ interface Props {
   onChange: (homeType?: string) => void;
 }
 
-function toHomeType(value: string) {
-  return value === ANY_HOME ? undefined : value;
-}
-
 const HomeType = ({ homeType, onChange }: Props) => <Container>
-  <Input
-    type="select"
-    name="homeType"
-    value={homeType}
-    onChange={event => onChange(toHomeType(event.target.value))}>
-    {HOME_TYPES.map(({ name, value }) => (
-      <option key={name} value={value}>
-        {name}
-      </option>
-    ))}
-  </Input>
+  <Row tag="form" className="form-check">
+    {HOME_TYPES.map(({ name, value }) => (<Col key={name}>
+      <Input
+        className="form-check-input"
+        id={name.toLowerCase()}
+        type="radio"
+        name="homeType"
+        value={value}
+        checked={homeType === value}
+        onChange={() => onChange(value)}
+      />
+      <label className="form-check-label" htmlFor={name.toLowerCase()}>{name}</label>
+    </Col>))}
+  </Row>
 </Container>;
 
 export default HomeType;

--- a/src/pages/search/filters/HomeType.tsx
+++ b/src/pages/search/filters/HomeType.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Alert, Col, Container, Input, Row } from 'reactstrap';
+
+import { HomeTypeAdminForm } from 'utils/validators';
+
+const HOME_TYPES = [
+  { name: 'Any', value: undefined },
+  ...(Object.values(HomeTypeAdminForm).map(
+    value => ({ name: value, value })
+  ))
+];
+
+interface Props {
+  homeType?: string;
+  onChange: (homeType?: string) => void;
+}
+
+const HomeType = ({ homeType, onChange }: Props) => <Container>
+  {HOME_TYPES.map(({ name, value }) => <h5 key={name}>
+    {name} <small>{value}</small>
+  </h5>)}
+</Container>;
+
+export default HomeType;

--- a/src/pages/search/filters/HomeType.tsx
+++ b/src/pages/search/filters/HomeType.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { Alert, Col, Container, Input, Row } from 'reactstrap';
+import { Container, Input } from 'reactstrap';
 
 import { HomeTypeAdminForm } from 'utils/validators';
 
+const ANY_HOME = 'Any Home Type';
 const HOME_TYPES = [
-  { name: 'Any', value: undefined },
+  { name: 'Any', value: ANY_HOME },
   ...(Object.values(HomeTypeAdminForm).map(
     value => ({ name: value, value })
   ))
@@ -15,10 +16,22 @@ interface Props {
   onChange: (homeType?: string) => void;
 }
 
+function toHomeType(value: string) {
+  return value === ANY_HOME ? undefined : value;
+}
+
 const HomeType = ({ homeType, onChange }: Props) => <Container>
-  {HOME_TYPES.map(({ name, value }) => <h5 key={name}>
-    {name} <small>{value}</small>
-  </h5>)}
+  <Input
+    type="select"
+    name="homeType"
+    value={homeType}
+    onChange={event => onChange(toHomeType(event.target.value))}>
+    {HOME_TYPES.map(({ name, value }) => (
+      <option key={name} value={value}>
+        {name}
+      </option>
+    ))}
+  </Input>
 </Container>;
 
 export default HomeType;

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -5,7 +5,7 @@ import GoogleAutoComplete from 'components/shared/GoogleAutoComplete';
 
 interface Props {
   place?: google.maps.places.PlaceResult;
-  onPlaceChange?: (place: google.maps.places.PlaceResult | null) => void;
+  onPlaceChange?: (place?: google.maps.places.PlaceResult) => void;
   onTravelModeChange?: (travelMode: google.maps.TravelMode) => void;
   travelMode?: google.maps.TravelMode;
 }
@@ -35,7 +35,7 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
       inputRef.current.value = "";
     }
     if (onPlaceChange) {
-      onPlaceChange(null);
+      onPlaceChange(undefined);
     }
   };
   const handleTravelMode = (mode: google.maps.TravelMode) => {

--- a/src/styled/customStyles.scss
+++ b/src/styled/customStyles.scss
@@ -45,9 +45,14 @@ $HEADER-HEIGHT: 4.125rem;
   height: calc(100vh - 11.25rem);
 }
 
-.bee-search-menu {
-  min-width: 16rem;
+.bee-search-menu-wide {
+  min-width: 24rem;
 }
+
+.bee-search-menu-narrow {
+  min-width: 9rem;
+}
+
 
 // add not-allowed cursor and no transform on disabled items
 * {

--- a/src/styled/customStyles.scss
+++ b/src/styled/customStyles.scss
@@ -45,6 +45,10 @@ $HEADER-HEIGHT: 4.125rem;
   height: calc(100vh - 11.25rem);
 }
 
+.bee-search-menu {
+  min-width: 25rem;
+}
+
 // add not-allowed cursor and no transform on disabled items
 * {
   &:disabled {

--- a/src/styled/customStyles.scss
+++ b/src/styled/customStyles.scss
@@ -45,7 +45,6 @@ $HEADER-HEIGHT: 4.125rem;
   height: calc(100vh - 11.25rem);
 }
 
-
 // add not-allowed cursor and no transform on disabled items
 * {
   &:disabled {

--- a/src/styled/customStyles.scss
+++ b/src/styled/customStyles.scss
@@ -45,14 +45,6 @@ $HEADER-HEIGHT: 4.125rem;
   height: calc(100vh - 11.25rem);
 }
 
-.bee-search-menu-wide {
-  min-width: 24rem;
-}
-
-.bee-search-menu-narrow {
-  min-width: 9rem;
-}
-
 
 // add not-allowed cursor and no transform on disabled items
 * {

--- a/src/styled/customStyles.scss
+++ b/src/styled/customStyles.scss
@@ -46,7 +46,7 @@ $HEADER-HEIGHT: 4.125rem;
 }
 
 .bee-search-menu {
-  min-width: 25rem;
+  min-width: 16rem;
 }
 
 // add not-allowed cursor and no transform on disabled items


### PR DESCRIPTION
## Description
Adds the "Home Type" filter from updated Beenest design

## How to Test
1. Search for some listings (e.g. in San Francisco, where we have many kinds)
2. Click "Home Type"
3. Choose a different home type
4. Expect listings to filter down to that home type
5. Regression test Destination filters

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
This exposes some UX issues that we may want to solve now, or carry:

1. Approach to dropdown width from #304 was broken (it depended on the dropdown button being in a full-width column, but that space is needed for more buttons). Solution here (explicit widths for dropdowns in rems) is not mobile friendly.
2. When a Home Type filter results in listings, the "No listings were found..." page displays, losing the context of the original search.
