### PR TITLE
Show price without cents on map

### DIFF
--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -8,7 +8,7 @@ const { GOOGLE_MAPS_KEY } = SETTINGS;
 
 import { ListingCard } from 'legacy/shared/ListingCard';
 import { LatLngBounds, ListingShort } from 'networking/listings';
-import { formatPrice } from 'utils/formatter';
+import { formatPriceShort } from 'utils/formatter';
 
 import GoogleMapsWithMarkersContainer from './GoogleMapsWithMarkers.container';
 
@@ -122,7 +122,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
               transform: 'translate(-50%, -100%)',
               zIndex: listings.length - index
             }} onClick={() => onSelect(listing)}>
-              <strong>{formatPrice(listing.pricePerNightUsd)}</strong>
+              <strong>{formatPriceShort(listing.pricePerNightUsd)}</strong>
               <div className="arrow" style={{ left: 'calc(50% - 12px)' }}></div>
             </button>
           </OverlayView>

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -42,6 +42,10 @@ export function formatPrice(price: number) { // TODO: Currency?
   return `\$${price.toFixed(2)}`;
 }
 
+export function formatPriceShort(price: number) {
+  return `\$${Math.ceil(price)}`;
+}
+
 export function formatMonth(date: Date | string) {
   return format(date, 'MMMM YYYY');
 }


### PR DESCRIPTION
## Description
Minor follow up to #308: Show prices on map as whole dollars to reduce visual noise

## How to Test
1. Search for listings in Tokyo
2. Find a listing with cents in the price
3. Locate same listing on map (e.g. by hovering)
4. Verify that marker on map shows whole dollar price, rounded *up*

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

