### PR TITLE
Use bookingUrl from BookingCard

### DIFF
--- a/src/networking/listings.ts
+++ b/src/networking/listings.ts
@@ -18,6 +18,7 @@ export interface Listing {
   airbnbLink?: string;
   amenities: string[];
   autoApprove: boolean;
+  bookingUrl?: string;
   checkInDate: Date;
   checkInTime: CheckInTime;
   checkOutDate: Date;
@@ -174,6 +175,7 @@ export interface Host {
 
 const LISTING_CARD_FRAGMENT = gql`
   fragment ListingCard on Listing {
+    bookingUrl
     city
     country
     homeType

--- a/src/pages/listing/BookingCard.tsx
+++ b/src/pages/listing/BookingCard.tsx
@@ -34,6 +34,7 @@ interface Props extends Listing {
 }
 
 const BookingCard = ({
+  bookingUrl,
   checkInDate,
   checkOutDate,
   createBooking,
@@ -135,7 +136,7 @@ const BookingCard = ({
         listingId: id,
         numberOfGuests: numberOfGuests
       });
-      window.location.href = `${BEENEST_HOST}/bookings/${data.createBooking.id}`;
+      window.location.href = bookingUrl || `${BEENEST_HOST}/bookings/${data.createBooking.id}`;
     } catch (e) {
       console.log(e);
       alert(e.message);


### PR DESCRIPTION
## Description
To allow bookings to be completed through Agoda's affiliate link, use `bookingUrl` provided from the backend.

Note that this depends on thebeetoken/beenest-backend#807 and should be reviewed/tested/merged after that.

## How to Test
Test affiliate link on Agoda listings:
1. Find an Agoda listing
2. Enter dates, click Request to Book
3. Expect to be taken to Agoda's site to finish booking

Regression test non-Agoda bookings of listings

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
