### PR TITLE
Catch errors loading Google Maps API

### DIFF
--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { withRouter } from 'react-router-dom';
-import { compose, withProps } from 'recompose';
+import { branch, compose, lifecycle, renderComponent, withProps } from 'recompose';
 import { DirectionsRenderer, InfoWindow, Marker, GoogleMap, OverlayView, withGoogleMap, withScriptjs } from 'react-google-maps';
 
 import { SETTINGS } from 'configs/settings';
@@ -155,6 +155,14 @@ export default withRouter(
         />
       ),
     })),
+    lifecycle({
+      // @ts-ignore
+      componentDidCatch(error: any, info: any) {
+        console.log(error, info);
+        this.setState({ error: true });
+      },
+    }),
+    branch(({ error }) => error, renderComponent(() => <h1>Error loading Google Maps.</h1>)),
     withScriptjs,
     withGoogleMap
   )(GoogleMapsWithMarkers)


### PR DESCRIPTION
## Description
We load the Google Maps JS API at run-time from another origin, so sometimes it is undefined. This adds a `componentDidCatch` and falls back to showing an error message when this occurs (same strategy is used in the GoogleMaps component, which we display on listing pages.)

May also prevent some of the map-related errors we see on Sentry; less certain of that, as I haven't been able to reproduce those.

## How to Test
1. Replace all references to `https://maps.googleapis.com/maps/api/js` in the code base to some broken URL
2. Try to search
3. Expect to see an error message in place of the map

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
In the old design, we hid the map and made room for listings when this happened. Not sure if it's worth reinvesting effort in that, since this is an off-nominal case and the map is more central to the redesign
