### PR TITLE
Add Apply button to Destination filter

### DIFF
--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -14,6 +14,12 @@ import GoogleMapsWithMarkersContainer from './GoogleMapsWithMarkers.container';
 
 const nearMarker = require('assets/images/iconmonstr-location-13-32.png');
 
+// https://github.com/tomchentw/react-google-maps/issues/405
+const keyFactory = {
+  counter: 0,
+  next() { return this.counter++; }
+};
+
 interface Props extends RouterProps {
   bounds?: LatLngBounds;
   children?: React.ReactNode;
@@ -114,7 +120,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
           listing => !selectedListing || listing.id !== selectedListing.id
         ).map((listing, index) => (
           <OverlayView
-            key={listing.id}
+            key={keyFactory.next()}
             position={{ lat: listing.lat, lng: listing.lng }}
             mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
           >

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, Col, Container, Input, Row } from 'reactstrap';
+import { Alert, Button, Col, Container, Input, Row } from 'reactstrap';
 
 import GoogleAutoComplete from 'components/shared/GoogleAutoComplete';
 
@@ -88,6 +88,9 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
         />
         <label className="form-check-label" htmlFor={name.toLowerCase()}>{name}</label>
       </Col>)}
+    </Row>
+    <Row className="mt-3 justify-content-end" noGutters>
+      <Button size="sm">Apply</Button>
     </Row>
   </Container>;
 }

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -5,8 +5,8 @@ import GoogleAutoComplete from 'components/shared/GoogleAutoComplete';
 
 interface Props {
   place?: google.maps.places.PlaceResult;
-  onPlaceChange?: (place?: google.maps.places.PlaceResult) => void;
-  onTravelModeChange?: (travelMode: google.maps.TravelMode) => void;
+  onPlaceChange: (place?: google.maps.places.PlaceResult) => void;
+  onTravelModeChange: (travelMode?: google.maps.TravelMode) => void;
   travelMode?: google.maps.TravelMode;
 }
 
@@ -18,35 +18,37 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
     'Cycling': google.maps.TravelMode.BICYCLING
   } : {};
   const [isAlertShowing, setAlertShowing] = React.useState<boolean>(false);
+  const [chosenPlace, setPlace] = React.useState(place);
+  const [chosenMode, setTravelMode] = React.useState(travelMode);
   const inputRef: React.RefObject<HTMLInputElement | null> = React.createRef();
+  const isDirty = (chosenPlace !== place) || (chosenMode !== travelMode);
 
   const handlePlace = (place: google.maps.places.PlaceResult) => {
     if (place && !place.geometry) {
       setAlertShowing(true);
       return;
     }
-    if (onPlaceChange) {
-      onPlaceChange(place);
-    }
+    setPlace(place);
   };
   const handleClear = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     event.preventDefault();
     if (inputRef.current) {
       inputRef.current.value = "";
     }
-    if (onPlaceChange) {
-      onPlaceChange(undefined);
-    }
+    setPlace(undefined);
   };
-  const handleTravelMode = (mode: google.maps.TravelMode) => {
-    if (onTravelModeChange) {
-      onTravelModeChange(mode);
+  const handleApply = () => {
+    if (place !== chosenPlace) {
+      onPlaceChange(chosenPlace);
+    }
+    if (travelMode !== chosenMode) {
+      onTravelModeChange(chosenMode);
     }
   };
 
   return <Container>
-    {place ? <h5>
-      {place.name}
+    {chosenPlace ? <h5>
+      {chosenPlace.name}
       <small className="ml-3">
         <a href="#" onClick={handleClear}>Clear</a>
        </small>
@@ -71,7 +73,7 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
         id="distanceFrom"
         name="distanceFrom"
         placeholder="Try &quot;Moscone Center&quot;"
-        defaultValue={place ? place.name : ''}
+        defaultValue={chosenPlace ? chosenPlace.name : ''}
         required />
     </GoogleAutoComplete>
     <h6 className="mt-3">Travel Mode</h6>
@@ -83,14 +85,16 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
           type="radio"
           name="travelMode"
           value={mode}
-          checked={(mode === travelMode) || (!travelMode && index === 0)}
-          onChange={() => mode && handleTravelMode(mode)}
+          checked={(mode === chosenMode) || (!chosenMode && index === 0)}
+          onChange={() => mode && setTravelMode(mode)}
         />
         <label className="form-check-label" htmlFor={name.toLowerCase()}>{name}</label>
       </Col>)}
     </Row>
     <Row className="mt-3 justify-content-end" noGutters>
-      <Button size="sm">Apply</Button>
+      <Button size="sm" disabled={!isDirty} onClick={handleApply}>
+        Apply
+      </Button>
     </Row>
   </Container>;
 }


### PR DESCRIPTION
## Description
Updating immediately on change from this component can be disorienting for the user; instead, add an Apply button so that changes to destination and travel mode can be completed before being applied.

## How to Test
1. Search for a city
2. Open the Destination filter
3. Expect "Apply" to be visible but disabled
4. Change Destination or Travel Mode
5. Expect "Apply" to be enabled
6. Click "Apply"
7. Expect search filters to be applied

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Now that there's an Apply button, I kinda want a little reset icon next to it...

