### PR TITLE
Allow same-day check-ins for searches

### DIFF
--- a/src/legacy/work/SearchBar/SearchBar.tsx
+++ b/src/legacy/work/SearchBar/SearchBar.tsx
@@ -75,8 +75,7 @@ class SearchBar extends React.Component<RouterProps, State> {
 
   private firstAvailableDay: moment.Moment = moment()
     .utc()
-    .startOf('day')
-    .add(2, 'days');
+    .startOf('day');
   private futureBlockedDates: moment.Moment = moment()
     .utc()
     .startOf('day')


### PR DESCRIPTION
## Description
Allow the user to select today as the check-in date on the SearchBar; most of our listings are Agoda listings which would be available for same-day bookings.

## How to Test
1. Go to front page
2. Open date picker
3. Verify that current date can be selected for check in date
4. Make a search
5. Verify that current date can still be selected from search bar
6. Click on a listing
7. Verify that current date can be selected from booking card

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
We've previously addressed this in the booking card (#101); did we miss anywhere else?
