### PR TITLE
Show rating in listing cards

### DIFF
--- a/src/networking/listings.ts
+++ b/src/networking/listings.ts
@@ -47,6 +47,7 @@ export interface Listing {
   postalCode: string;
   pricePerNightUsd: number;
   prices: Price[];
+  rating: Rating;
   reservations: Reservation[];
   securityDepositUsd: number;
   sharedBathroom: string;
@@ -81,6 +82,7 @@ export interface ListingShort {
   listingPicUrl: string;
   pricePerNightUsd: number;
   prices: Price[];
+  rating: Rating;
   sleepingArrangement: string;
   state: string;
   title: string;
@@ -158,6 +160,11 @@ export interface Price {
   securityDeposit: number;
 }
 
+export interface Rating {
+  average: number;
+  count: number;
+}
+
 export interface Reservation {
   startDate: Date;
   endDate: Date;
@@ -186,6 +193,10 @@ const LISTING_CARD_FRAGMENT = gql`
       currency
       pricePerNight
       securityDeposit
+    }
+    rating {
+      average
+      count
     }
     sleepingArrangement
     state

--- a/src/pages/search/ListingCard.tsx
+++ b/src/pages/search/ListingCard.tsx
@@ -7,6 +7,7 @@ const ListingCard = ({
   homeType,
   listingPicUrl,
   pricePerNightUsd,
+  rating,
   title
 }: ListingShort) => (
   <Card tag={Fade} className="w-100 h-100 shadow border-0">
@@ -16,7 +17,10 @@ const ListingCard = ({
       </div>
     </div>
     <CardBody>
-      <CardSubtitle className="small text-secondary">{homeType}</CardSubtitle>
+      <CardSubtitle className="small text-secondary">
+        {homeType}
+        {rating && <span> &middot; {rating.average}/10 rating</span>}
+      </CardSubtitle>
       <CardTitle tag="h6">{title}</CardTitle>
     </CardBody>
     <CardFooter>


### PR DESCRIPTION
## Description
To support more informed booking decisions, display rating information in listing cards for search results, when that information is available.

## How to Test
1. Search for listings somewhere with Agoda listings
2. Expect to see rating information (e.g. "8.1/10 rating") in listing cards.

Note that this depends upon thebeetoken/beenest-backend#811

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
* Display as stars? (Of course we're going to want to display these as stars)
* Display on listing page
