### PR TITLE
Reduce whitespace in ListingCard

### DIFF
--- a/src/pages/search/ListingCard.tsx
+++ b/src/pages/search/ListingCard.tsx
@@ -17,7 +17,7 @@ const ListingCard = ({
     </div>
     <CardBody>
       <CardSubtitle className="small text-secondary">{homeType}</CardSubtitle>
-      <CardTitle tag="h6">{title}</CardTitle>
+      <CardTitle className="mb-0" tag="h6">{title}</CardTitle>
     </CardBody>
     <CardFooter>
       <CardText>${pricePerNightUsd} per night</CardText>


### PR DESCRIPTION
## Description
`card-title` includes `1rem` of `margin-bottom` by default; this results in a full blank line of whitespace in every card shown in search.

So, set `mb-0` to remove this margin to show guests more listings in the same amount of vertical space

## How to Test
1. Search for some listings
2. Look at height of listing card
3. Verify that there is no extra whitespace (except in cases where it is to achieve the same height as the neighboring card)

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
