### PR TITLE
Keep search filters in query string

### DIFF
--- a/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
+++ b/src/legacy/shared/GoogleMapsWithMarkers/GoogleMapsWithMarkers.tsx
@@ -7,7 +7,7 @@ import { SETTINGS } from 'configs/settings';
 const { GOOGLE_MAPS_KEY } = SETTINGS;
 
 import { ListingCard } from 'legacy/shared/ListingCard';
-import { LatLngBounds, ListingShort } from 'networking/listings';
+import { LatLng, LatLngBounds, ListingShort } from 'networking/listings';
 import { formatPriceShort } from 'utils/formatter';
 
 import GoogleMapsWithMarkersContainer from './GoogleMapsWithMarkers.container';
@@ -20,6 +20,10 @@ const keyFactory = {
   next() { return this.counter++; }
 };
 
+interface NamedLatLng extends LatLng {
+  name: string;
+}
+
 interface Props extends RouterProps {
   bounds?: LatLngBounds;
   children?: React.ReactNode;
@@ -27,7 +31,7 @@ interface Props extends RouterProps {
   height?: string;
   selectedListing?: ListingShort;
   listings: ListingShort[];
-  near?: google.maps.places.PlaceResult;
+  near?: NamedLatLng;
   travelMode?: google.maps.TravelMode;
   width?: string;
   onSelect: (listing: ListingShort | null) => void;
@@ -77,7 +81,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
       const directionsService = new google.maps.DirectionsService();
       directionsService.route({
         origin: { lat: selectedListing.lat, lng: selectedListing.lng },
-        destination: near.geometry.location,
+        destination: near,
         travelMode: travelMode || google.maps.TravelMode.DRIVING
       }, (directions, status) => {
         if (status === google.maps.DirectionsStatus.OK) {
@@ -112,7 +116,7 @@ class GoogleMapsWithMarkers extends React.Component<Props, State> {
             fontSize: '1rem',
             text: near.name
           }}
-          position={near.geometry.location}
+          position={near}
           title={near.name}
           zIndex={1000}
         />}

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -37,7 +37,6 @@ const Search = () => {
           listings={data.searchListings}
           filter={filter}
           onFilterChange={setFilter}
-          {...queryParams}
         />;
       }}
     </Query>

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -11,7 +11,6 @@ import SearchBar from 'legacy/work/SearchBar';
 import { VIEWPORT_CENTER_LAYOUT } from 'styled/sharedClasses/layout';
 
 import { LISTING_CARD_IMAGE_DIMENSIONS } from 'utils/imageDimensions';
-import { parseQueryString } from 'utils/queryParams';
 import { getFriendlyErrorMessage } from 'utils/validators';
 
 import { SearchFilterCriteria, toListingSearchInput, queryToCriteria } from './SearchCriteria';

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -90,6 +90,11 @@ const EmptySearchPage = () => (
   </Container>
 );
 
-const isBadUserInputError = (error: ApolloError) => error && error.graphQLErrors[0].extensions && error.graphQLErrors[0].extensions.code === 'BAD_USER_INPUT';
+const isBadUserInputError = (error: ApolloError) =>
+  error &&
+  error.graphQLErrors &&
+  error.graphQLErrors[0] &&
+  error.graphQLErrors[0].extensions &&
+  error.graphQLErrors[0].extensions.code === 'BAD_USER_INPUT';
 
 export default Search;

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -14,28 +14,12 @@ import { LISTING_CARD_IMAGE_DIMENSIONS } from 'utils/imageDimensions';
 import { parseQueryString } from 'utils/queryParams';
 import { getFriendlyErrorMessage } from 'utils/validators';
 
-import { SearchFilterCriteria, toListingSearchInput } from './SearchCriteria';
+import { SearchFilterCriteria, toListingSearchInput, queryToCriteria } from './SearchCriteria';
 import SearchPage from './SearchPage';
 
-const SEARCH_PARAMS = [
-  'bounds',
-  'coordinates',
-  'locationQuery',
-  'checkInDate',
-  'checkOutDate',
-  'numberOfGuests'
-];
-
 const Search = () => {
-  const [filter, setFilter] = React.useState<SearchFilterCriteria>({
-    travelMode: typeof google !== 'undefined' ? google.maps.TravelMode.DRIVING : undefined
-  });
-  const queryParams: any = parseQueryString(location.search);
-  const queryInput: any = SEARCH_PARAMS.reduce(
-    (obj, param) => queryParams[param] ? { ...obj, [param]: queryParams[param] } : obj,
-    {}
-  );
-  const input = { ...queryInput, ...toListingSearchInput(filter) };
+  const [filter, setFilter] = React.useState<SearchFilterCriteria>(queryToCriteria(location.search));
+  const input = toListingSearchInput(filter);
   return (<Fade>
     <Query query={SEARCH_LISTINGS} variables={{ input, ...LISTING_CARD_IMAGE_DIMENSIONS }}>
       {({ loading, error, data }) => {

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -13,12 +13,18 @@ import { VIEWPORT_CENTER_LAYOUT } from 'styled/sharedClasses/layout';
 import { LISTING_CARD_IMAGE_DIMENSIONS } from 'utils/imageDimensions';
 import { getFriendlyErrorMessage } from 'utils/validators';
 
-import { SearchFilterCriteria, toListingSearchInput, queryToCriteria } from './SearchCriteria';
+import { SearchFilterCriteria, criteriaToQuery, toListingSearchInput, queryToCriteria } from './SearchCriteria';
 import SearchPage from './SearchPage';
 
 const Search = () => {
   const [filter, setFilter] = React.useState<SearchFilterCriteria>(queryToCriteria(location.search));
   const input = toListingSearchInput(filter);
+  React.useEffect(() => {
+    const queryString = `?${criteriaToQuery(filter)}`;
+    if (queryString !== window.location.search) {
+      window.location.search = queryString;
+    }
+  }, [filter]);
   return (<Fade>
     <Query query={SEARCH_LISTINGS} variables={{ input, ...LISTING_CARD_IMAGE_DIMENSIONS }}>
       {({ loading, error, data }) => {

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -49,8 +49,8 @@ export function queryToCriteria(queryString: string): SearchFilterCriteria {
       south: parseFloat(queryParams.bounds.south)
     },
     coordinates: queryParams.coordinates && {
-      lat: parseFloat(queryParams.bounds.lat),
-      lng: parseFloat(queryParams.bounds.lng)
+      lat: parseFloat(queryParams.coordinates.lat),
+      lng: parseFloat(queryParams.coordinates.lng)
     },
     homeType: queryParams.homeType,
     numberOfGuests: queryParams.numberOfGuests && parseInt(queryParams.numberOfGuests),

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -1,13 +1,13 @@
 import { LatLng, LatLngBounds, ListingSearchInput } from 'networking/listings';
 import { parseQueryString } from 'utils/queryParams';
 
-interface NamedLatLng extends LatLng {
+export interface NamedLatLng extends LatLng {
   name: string;
 }
 
 // Redundant to google.maps.TravelMode, but that may be unavailable at
 // initialization-time; it loads asynchronously.
-enum TravelMode {
+export enum TravelMode {
   DRIVING,
   WALKING,
   TRANSIT,
@@ -26,7 +26,7 @@ export interface SearchFilterCriteria {
   near?: NamedLatLng;
 }
 
-export function toGoogleTravelMode(travelMode: TravelMode) {
+export function toGoogleTravelMode(travelMode?: TravelMode): google.maps.TravelMode | undefined {
   if (typeof google === 'undefined') {
     return undefined;
   }
@@ -36,6 +36,7 @@ export function toGoogleTravelMode(travelMode: TravelMode) {
   case TravelMode.TRANSIT: return google.maps.TravelMode.TRANSIT;
   case TravelMode.BICYCLING: return google.maps.TravelMode.BICYCLING;
   }
+  return undefined;
 }
 
 export function queryToCriteria(queryString: string): SearchFilterCriteria {
@@ -58,12 +59,6 @@ export function queryToCriteria(queryString: string): SearchFilterCriteria {
   };
 }
 
-export function toListingSearchInput({ near, homeType }: SearchFilterCriteria): ListingSearchInput {
-  return {
-    near: near && {
-      lat: near.geometry.location.lat(),
-      lng: near.geometry.location.lng()
-    },
-    homeType
-  };
+export function toListingSearchInput(criteria: SearchFilterCriteria): ListingSearchInput {
+  return criteria;
 }

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -1,17 +1,6 @@
 import { LatLng, LatLngBounds, ListingSearchInput } from 'networking/listings';
 import { parseQueryString } from 'utils/queryParams';
 
-const SEARCH_PARAMS = [
-  'bounds',
-  'coordinates',
-  'locationQuery',
-  'checkInDate',
-  'checkOutDate',
-  'near',
-  'numberOfGuests',
-  'travelMode'
-];
-
 export interface SearchFilterCriteria {
   bounds?: LatLngBounds;
   checkInDate?: string;

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -40,7 +40,7 @@ export function queryToCriteria(queryString: string): SearchFilterCriteria {
     homeType: queryParams.homeType,
     numberOfGuests: queryParams.numberOfGuests && parseInt(queryParams.numberOfGuests),
     travelMode: queryParams.travelMode,
-
+    near: queryParams.near
   };
 }
 

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -1,5 +1,5 @@
 import { LatLng, LatLngBounds, ListingSearchInput } from 'networking/listings';
-import { parseQueryString } from 'utils/queryParams';
+import { parseQueryString, stringifyQueryString } from 'utils/queryParams';
 
 export interface NamedLatLng extends LatLng {
   name: string;
@@ -8,10 +8,10 @@ export interface NamedLatLng extends LatLng {
 // Redundant to google.maps.TravelMode, but that may be unavailable at
 // initialization-time; it loads asynchronously.
 export enum TravelMode {
-  DRIVING,
-  WALKING,
-  TRANSIT,
-  BICYCLING
+  DRIVING = "DRIVING",
+  WALKING = "WALKING",
+  TRANSIT = "TRANSIT",
+  BICYCLING = "CYCLING"
 }
 
 export interface SearchFilterCriteria {
@@ -57,6 +57,10 @@ export function queryToCriteria(queryString: string): SearchFilterCriteria {
     travelMode: queryParams.travelMode,
     near: queryParams.near
   };
+}
+
+export function criteriaToQuery(criteria: SearchFilterCriteria): string {
+  return stringifyQueryString({ ...criteria, utm_term: criteria.locationQuery });
 }
 
 export function toListingSearchInput({

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -59,6 +59,27 @@ export function queryToCriteria(queryString: string): SearchFilterCriteria {
   };
 }
 
-export function toListingSearchInput(criteria: SearchFilterCriteria): ListingSearchInput {
-  return criteria;
+export function toListingSearchInput({
+  bounds,
+  checkInDate,
+  checkOutDate,
+  coordinates,
+  homeType,
+  locationQuery,
+  numberOfGuests,
+  near
+}: SearchFilterCriteria): ListingSearchInput {
+  return {
+    bounds,
+    checkInDate,
+    checkOutDate,
+    coordinates,
+    homeType,
+    locationQuery,
+    numberOfGuests,
+    near: near && {
+      lat: near.lat,
+      lng: near.lng
+    }
+  };
 }

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -1,6 +1,19 @@
 import { LatLng, LatLngBounds, ListingSearchInput } from 'networking/listings';
 import { parseQueryString } from 'utils/queryParams';
 
+interface NamedLatLng extends LatLng {
+  name: string;
+}
+
+// Redundant to google.maps.TravelMode, but that may be unavailable at
+// initialization-time; it loads asynchronously.
+enum TravelMode {
+  DRIVING,
+  WALKING,
+  TRANSIT,
+  BICYCLING
+}
+
 export interface SearchFilterCriteria {
   bounds?: LatLngBounds;
   checkInDate?: string;
@@ -9,8 +22,20 @@ export interface SearchFilterCriteria {
   homeType?: string;
   locationQuery?: string;
   numberOfGuests?: number;
-  travelMode?: google.maps.TravelMode;
-  near?: google.maps.places.PlaceResult;
+  travelMode?: TravelMode;
+  near?: NamedLatLng;
+}
+
+export function toGoogleTravelMode(travelMode: TravelMode) {
+  if (typeof google === 'undefined') {
+    return undefined;
+  }
+  switch (travelMode) {
+  case TravelMode.DRIVING: return google.maps.TravelMode.DRIVING;
+  case TravelMode.WALKING: return google.maps.TravelMode.WALKING;
+  case TravelMode.TRANSIT: return google.maps.TravelMode.TRANSIT;
+  case TravelMode.BICYCLING: return google.maps.TravelMode.BICYCLING;
+  }
 }
 
 export function queryToCriteria(queryString: string): SearchFilterCriteria {

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -1,9 +1,47 @@
-import { ListingSearchInput } from 'networking/listings';
+import { LatLng, LatLngBounds, ListingSearchInput } from 'networking/listings';
+import { parseQueryString } from 'utils/queryParams';
+
+const SEARCH_PARAMS = [
+  'bounds',
+  'coordinates',
+  'locationQuery',
+  'checkInDate',
+  'checkOutDate',
+  'near',
+  'numberOfGuests',
+  'travelMode'
+];
 
 export interface SearchFilterCriteria {
+  bounds?: LatLngBounds;
+  checkInDate?: string;
+  checkOutDate?: string;
+  coordinates?: LatLng;
   homeType?: string;
+  locationQuery?: string;
+  numberOfGuests?: number;
   travelMode?: google.maps.TravelMode;
   near?: google.maps.places.PlaceResult;
+}
+
+export function queryToCriteria(queryString: string): SearchFilterCriteria {
+  const queryParams: any = parseQueryString(queryString);
+  return {
+    bounds: queryParams.bounds && {
+      east: parseFloat(queryParams.bounds.east),
+      west: parseFloat(queryParams.bounds.west),
+      north: parseFloat(queryParams.bounds.north),
+      south: parseFloat(queryParams.bounds.south)
+    },
+    coordinates: queryParams.coordinates && {
+      lat: parseFloat(queryParams.bounds.lat),
+      lng: parseFloat(queryParams.bounds.lng)
+    },
+    homeType: queryParams.homeType,
+    numberOfGuests: queryParams.numberOfGuests && parseInt(queryParams.numberOfGuests),
+    travelMode: queryParams.travelMode,
+
+  };
 }
 
 export function toListingSearchInput({ near, homeType }: SearchFilterCriteria): ListingSearchInput {

--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -55,7 +55,11 @@ export function queryToCriteria(queryString: string): SearchFilterCriteria {
     homeType: queryParams.homeType,
     numberOfGuests: queryParams.numberOfGuests && parseInt(queryParams.numberOfGuests),
     travelMode: queryParams.travelMode,
-    near: queryParams.near
+    near: queryParams.near && {
+      lat: parseFloat(queryParams.near.lat),
+      lng: parseFloat(queryParams.near.lng),
+      name: queryParams.near.name
+    }
   };
 }
 

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -8,7 +8,7 @@ import SearchBar from 'legacy/work/SearchBar';
 
 import { useDebounce } from 'utils/hooks';
 
-import { SearchFilterCriteria } from './SearchCriteria';
+import { SearchFilterCriteria, toGoogleTravelMode } from './SearchCriteria';
 import SearchForm from './SearchForm';
 import SearchResults from './SearchResults';
 
@@ -56,7 +56,7 @@ const SearchPage = ({
             className="w-100 h-100"
             listings={listings}
             near={filter.near}
-            travelMode={filter.travelMode}
+            travelMode={toGoogleTravelMode(filter.travelMode)}
             selectedListing={debouncedListing || undefined}
             onSelect={selectListing}
           />

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -13,22 +13,17 @@ import SearchForm from './SearchForm';
 import SearchResults from './SearchResults';
 
 interface Props {
-  checkInDate?: string;
-  checkOutDate?: string;
-  numberOfGuests?: number;
   onFilterChange: (filter: SearchFilterCriteria) => void;
   filter: SearchFilterCriteria;
   listings: Listing[];
 }
 
 const SearchPage = ({
-  checkInDate,
-  checkOutDate,
-  numberOfGuests,
   filter,
   onFilterChange,
   listings
 }: Props) => {
+  const { checkInDate, checkOutDate, numberOfGuests } = filter;
   const [selectedListing, selectListing] = React.useState<ListingShort | null>(null);
   const debouncedListing = useDebounce(selectedListing, 125);
   return <Fade>

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -3,20 +3,22 @@ import { Alert, Button, Col, Container, Input, Row } from 'reactstrap';
 
 import GoogleAutoComplete from 'components/shared/GoogleAutoComplete';
 
+import { NamedLatLng, TravelMode } from '../SearchCriteria';
+
 interface Props {
-  place?: google.maps.places.PlaceResult;
-  onPlaceChange: (place?: google.maps.places.PlaceResult) => void;
-  onTravelModeChange: (travelMode?: google.maps.TravelMode) => void;
-  travelMode?: google.maps.TravelMode;
+  place?: NamedLatLng;
+  onPlaceChange: (place?: NamedLatLng) => void;
+  onTravelModeChange: (travelMode?: TravelMode) => void;
+  travelMode?: TravelMode;
 }
 
 const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: Props) => {
-  const travelModes = typeof google !== 'undefined' ? {
-    'Driving': google.maps.TravelMode.DRIVING,
-    'Transit': google.maps.TravelMode.TRANSIT,
-    'Walking': google.maps.TravelMode.WALKING,
-    'Cycling': google.maps.TravelMode.BICYCLING
-  } : {};
+  const travelModes = {
+    'Driving': TravelMode.DRIVING,
+    'Transit': TravelMode.TRANSIT,
+    'Walking': TravelMode.WALKING,
+    'Cycling': TravelMode.BICYCLING
+  };
   const [isAlertShowing, setAlertShowing] = React.useState<boolean>(false);
   const [chosenPlace, setPlace] = React.useState(place);
   const [chosenMode, setTravelMode] = React.useState(travelMode);
@@ -28,7 +30,11 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
       setAlertShowing(true);
       return;
     }
-    setPlace(place);
+    setPlace({
+      lat: place.geometry.location.lat(),
+      lng: place.geometry.location.lng(),
+      name: place.name
+    });
   };
   const handleClear = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     event.preventDefault();

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -92,7 +92,7 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
           name="travelMode"
           value={mode}
           checked={(mode === chosenMode) || (!chosenMode && index === 0)}
-          onChange={() => mode && setTravelMode(mode)}
+          onChange={() => setTravelMode(mode)}
         />
         <label className="form-check-label" htmlFor={name.toLowerCase()}>{name}</label>
       </Col>)}


### PR DESCRIPTION
## Description
Keeps user's chosen destination (and other search filter parameters, why not?) in the query string so that specific searches can easily be shared, information is not lost on reload, and so on.

Note that this has been branched from #326 and should be reviewed/merged after that PR has been merged

## How to Test
1. Make a search
2. For each of Destination, Travel Mode, and Home Type:
    1. Change the filter
    2. Reload
    3. Verify selection is still present and reflected on map and in listing results

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
