### PR TITLE
fix preview button border

### DIFF
--- a/src/legacy/routes/Host/HostListingCard/HostListingCard.tsx
+++ b/src/legacy/routes/Host/HostListingCard/HostListingCard.tsx
@@ -112,12 +112,16 @@ const HostListingCard = (props: Props): JSX.Element => {
                 </Link>
               </Col>
               <Col md="6" lg="3" className="mb-2 mb-lg-0">
-                <Link
+                <Button
+                  outline
+                  tag={Link}
                   target="_blank"
                   to={`/listings/${idSlug}`}
-                  className="w-100 rounded-lg btn btn-sm btn-white btn-outline-secondary">
+                  color="secondary"
+                  size="sm"
+                  className="w-100 rounded-lg">
                   Preview
-                </Link>
+                </Button>
               </Col>
               <Col md="6" lg="3" className="mb-2 mb-lg-0">
                 <Button outline color="secondary" size="sm" className="w-100 rounded-lg" onClick={() => duplicateListing(id)}>


### PR DESCRIPTION
## Description
Why did you write this code?
Preview button loses border on safari:
![image](https://user-images.githubusercontent.com/18321302/54553859-5dc70680-4970-11e9-936a-1767dc29328f.png)


## How to Test
- [ ] Visit host/listings
- [ ] See preview button border is there on all screens and hover is consistent with the other buttons

Which devices did you test on?
- [x] Chrome on Mac
- [x] Safari on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

