### PR TITLE
Add a Host CTA to home page

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Button, Col, Container, Fade, Jumbotron, Row } from 'reactstrap';
+import { Link } from 'react-router-dom';
 
 import { affiliations, guestValueProps, HomeUser, hostValueProps, testimonials } from './home.config';
 
@@ -142,7 +143,11 @@ const HomeHosts = () => (
       <h3 className={CONTENT_CLASSES.TITLE}>Want to rent out your homes to professionals?</h3>
       <p className={CONTENT_CLASSES.SUBTITLE}>
         Here, your guests will be business travelers so don’t worry about parties.
-        </p>
+      </p>
+
+      <Link to="/host/listings">
+        <Button color="primary">Add a Listing</Button>
+      </Link>
 
       <Row className={CONTENT_CLASSES.FEATURES.LAYOUT}>
         {hostValueProps.map(card => (

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -145,8 +145,10 @@ const HomeHosts = () => (
         Here, your guests will be business travelers so don’t worry about parties.
       </p>
 
-      <Link to="/host/listings">
-        <Button color="primary">Add a Listing</Button>
+      <Link to="/host/listings" className="w-100 w-md-auto px-7">
+        <Button color="primary" className="w-100">
+          Add a Listing
+        </Button>
       </Link>
 
       <Row className={CONTENT_CLASSES.FEATURES.LAYOUT}>


### PR DESCRIPTION
## Description
Adds a CTA to solicit listings to the home page, similar to what we had prior to the redesign

## How to Test
1. Go to the home page
2. Click "I'm a Host"
3. Expect an "Add a Listing" button to be visible
4. Click that button
5. Expect to go to `/host/listings` (if signed in; otherwise, to signup form)

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Do we want to dynamically decide the functionality of this button based on the current user, like we do in the Header? (I started down that path, then decided to start simple.)
