### PR TITLE
Reduce info window opacity when driving directions show

### DIFF
--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -49,7 +49,7 @@ const SearchPage = ({
       <Col md="0" lg="7" xl="8" className="px-0 d-md-none d-lg-block">
         <div className="w-100 sticky-top bee-top bee-search-map z-index-0">
           <GoogleMapsWithMarkers
-            className="w-100 h-100"
+            className={`w-100 h-100${!!filter.near ? ' bee-directions-showing' : ''}`}
             listings={listings}
             near={filter.near}
             travelMode={toGoogleTravelMode(filter.travelMode)}

--- a/src/styled/customStyles.scss
+++ b/src/styled/customStyles.scss
@@ -122,9 +122,11 @@ $HEADER-HEIGHT: 4.125rem;
 .bee-directions-showing {
   .gm-style-iw {
     opacity: 0.75;
+    transition: all 0.2s ease-in-out;
   }
 
   .gm-style .gm-style-iw:hover {
     opacity: 1;
+    transition: all 0.2s ease-in-out;
   }
 }

--- a/src/styled/customStyles.scss
+++ b/src/styled/customStyles.scss
@@ -118,3 +118,13 @@ $HEADER-HEIGHT: 4.125rem;
   position: relative;
   z-index: 10000;
 }
+
+.bee-directions-showing {
+  .gm-style-iw {
+    opacity: 0.75;
+  }
+
+  .gm-style .gm-style-iw:hover {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Description
To ensure driving directions are not obscured by the Info Window containing listing information, reduce the opacity of that window when directions are being shown (and restore opacity on hover)

## How to Test
1. Do a search which results in some listings
2. Open Destination filter, choose a place and travel mode, click Apply
3. Hover over listings on the left
4. Expect Info Window to appear at 75% opacity, with driving directions visible underneath (in those cases when they'd be otherwise obscured)
5. Click on listing in the map to open its Info Window, expect that to be at 75%
6. Hover over that Info Window
7. Expect full opacity at that point
8. Clear Destination, click Apply
9. Hover over listings on left
10. Expect listing Info Windows in map to be full opacity

<img width="318" alt="image" src="https://user-images.githubusercontent.com/42747169/54571528-561f5600-49a0-11e9-9dd3-2deeeb1aa723.png">


Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

