### PR TITLE
Show route duration on map WIP

### DIFF
--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -49,3 +49,10 @@ export function formatPriceShort(price: number) {
 export function formatMonth(date: Date | string) {
   return format(date, 'MMMM YYYY');
 }
+
+export function formatDuration(seconds: number) {
+  const s = seconds % 60;
+  const m = Math.floor(seconds / 60) % 60;
+  const h = Math.floor(seconds / 3600);
+  return `${h}:${m < 10 ? '0' : ''}${m}:${s < 10 ? '0' : ''}${s}`;
+}


### PR DESCRIPTION
## Description
To provide users with more useful context when selecting hotels, show duration associated with driving directions on map

## How to Test
1. Search
2. Enter a Destination filter
3. Select listings to show directions
4. Expect duration of travel to display on map, half-way along the path

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?
