### PR TITLE
Retain search params as filter criteria

### DIFF
--- a/src/pages/search/SearchCriteria.ts
+++ b/src/pages/search/SearchCriteria.ts
@@ -48,11 +48,14 @@ export function queryToCriteria(queryString: string): SearchFilterCriteria {
       north: parseFloat(queryParams.bounds.north),
       south: parseFloat(queryParams.bounds.south)
     },
+    checkInDate: queryParams.checkInDate,
+    checkOutDate: queryParams.checkOutDate,
     coordinates: queryParams.coordinates && {
       lat: parseFloat(queryParams.coordinates.lat),
       lng: parseFloat(queryParams.coordinates.lng)
     },
     homeType: queryParams.homeType,
+    locationQuery: queryParams.locationQuery,
     numberOfGuests: queryParams.numberOfGuests && parseInt(queryParams.numberOfGuests),
     travelMode: queryParams.travelMode,
     near: queryParams.near && {


### PR DESCRIPTION
## Description
Noticed that some searches were losing search parameters, in certain circumstances. Investigated and found that #327 omitted some properties from its conversion functions.

## How to Test
1. Go to home page
2. Enter a search location and tab out (don't click on an autocomplete result)
3. Enter check in, check out dates
4. Set number of guests to something other than 1
5. Click Search
6. Expect search parameters to be retained

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
I think there are some interactions with the search bar which lose filter parameters as well. Presently investigating, will hotfix separately

## Learnings
We [considered unifying these interfaces](https://github.com/thebeetoken/beenest-web/pull/326#discussion_r266142185) but opted against it due to level-of-effort. Think that decision makes sense, but it's worth noting that the conversion functions which introduced this bug would have been made obsolete by that investment.

