### PR TITLE
Remove BTC from booking options

### DIFF
--- a/src/legacy/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
+++ b/src/legacy/routes/Booking/BookingOptions/SelectPaymentOption/SelectPaymentOption.tsx
@@ -5,7 +5,6 @@ import { Col, Fade, Row } from 'reactstrap';
 
 import SelectPaymentOptionContainer from './SelectPaymentOption.container';
 import BookingOptionsUSD from '../BookingOptionsUSD';
-import BookingOptionsBTC from '../BookingOptionsBTC';
 import BookingQuote from '../../BookingQuote';
 import BookingOptionsCrypto from '../BookingOptionsCrypto';
 
@@ -35,8 +34,6 @@ class SelectPaymentOption extends React.Component<Props> {
     const { booking } = this.props;
     const showBee = !!booking.host.walletAddress;
     const showEth = !!booking.host.walletAddress;
-    const showBtc =
-      booking.priceQuotes.some(({ currency }) => currency === Currency.BTC);
     // The 1.01 multiplier below accounts for fluctuating exchange rates etc.
     const fromBee = errorPricingToken ?
       (() => '--.--') :
@@ -62,7 +59,6 @@ class SelectPaymentOption extends React.Component<Props> {
                     {showBee && <option value={Currency.BEE}>BEE</option>}
                     {showBee && <option value={Currency.DAI}>DAI</option>}
                     {showEth && <option value={Currency.ETH}>ETH</option>}
-                    {showBtc && <option value={Currency.BTC}>BTC</option>}
                     <option value={Currency.USD}>Credit Card</option>
                   </select>
                   <Svg className="suffix" src="utils/carat-down" />
@@ -115,8 +111,6 @@ function currencyOptions(currency: string | undefined, booking: Booking, fromBee
       return <Fade><BookingOptionsCrypto booking={booking} currency={currency} fromBee={fromBee} /></Fade>;
     case Currency.USD:
       return <Fade><BookingOptionsUSD booking={booking} /></Fade>;
-    case Currency.BTC:
-      return <Fade><BookingOptionsBTC booking={booking} /></Fade>;
     default:
       return null;
   }


### PR DESCRIPTION
## Description
...to decrease the operational support needed to run beenest

## How to Test
1. Navigate to a listing whose host has a BTC address
2. Proceed to booking
3. Verify that BTC is not available

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
1. Remove dead code
2. Remove UI to add BTC wallet addresses
3. Remove server-side support
