### PR TITLE
Fix bug with Destination filter

### DIFF
--- a/src/pages/search/SearchForm.tsx
+++ b/src/pages/search/SearchForm.tsx
@@ -25,8 +25,7 @@ const SearchForm = ({ filter, onFilterChange }: Props) => {
           <TransitTime
             place={filter.near}
             travelMode={filter.travelMode}
-            onPlaceChange={near => onFilterChange({ ...filter, near })}
-            onTravelModeChange={travelMode => onFilterChange({ ...filter, travelMode })}
+            onChange={(near, travelMode) => onFilterChange({ ...filter, near, travelMode })}
           />
         </SearchFilter>
       </ButtonGroup>

--- a/src/pages/search/filters/TransitTime.tsx
+++ b/src/pages/search/filters/TransitTime.tsx
@@ -7,12 +7,11 @@ import { NamedLatLng, TravelMode } from '../SearchCriteria';
 
 interface Props {
   place?: NamedLatLng;
-  onPlaceChange: (place?: NamedLatLng) => void;
-  onTravelModeChange: (travelMode?: TravelMode) => void;
+  onChange: (place?: NamedLatLng, travelMode?: TravelMode) => void;
   travelMode?: TravelMode;
 }
 
-const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: Props) => {
+const TransitTime = ({ place, onChange, travelMode }: Props) => {
   const travelModes = {
     'Driving': TravelMode.DRIVING,
     'Transit': TravelMode.TRANSIT,
@@ -42,14 +41,6 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
       inputRef.current.value = "";
     }
     setPlace(undefined);
-  };
-  const handleApply = () => {
-    if (place !== chosenPlace) {
-      onPlaceChange(chosenPlace);
-    }
-    if (travelMode !== chosenMode) {
-      onTravelModeChange(chosenMode);
-    }
   };
 
   return <Container>
@@ -98,7 +89,7 @@ const TransitTime = ({ place, onPlaceChange, onTravelModeChange, travelMode }: P
       </Col>)}
     </Row>
     <Row className="mt-3 justify-content-end" noGutters>
-      <Button size="sm" disabled={!isDirty} onClick={handleApply}>
+      <Button size="sm" disabled={!isDirty} onClick={() => onChange(chosenPlace, chosenMode)}>
         Apply
       </Button>
     </Row>


### PR DESCRIPTION
## Description
Pass both filter parameters up at the same time on apply, to avoid clobbering changes from separate callbacks.

This addresses the issue noted in Further Work of #341. Changing both destination and travel mode with separate calls on the same Apply caused the former to be lost, because of the nature of the handlers involved.

## How to Test
1. Search (e.g. for San Francisco)
2. Open the Destination dropdown
3. Enter a place (e.g. Coit Tower; select it from the list)
4. Change the travel mode
5. Click Apply
6. Expect destination to appear on map and for travel mode preference to be retained/reflected

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
None expected!

## Learnings
`useState` has some "quirks" (at least if you come at it expecting it to work like `setState`)

In particular, this two-callback solution:

    onPlaceChange={near => onFilterChange({ ...filter, near })}
    onTravelModeChange={travelMode => onFilterChange({ ...filter, travelMode })}

...caused the loss of `near` when the two are executed in sequence, because `filter` is still the same value returned from the prior `useState` call in both cases.