### PR TITLE
direct search error page to correct page

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -46,7 +46,7 @@ class ScrollToTop extends React.Component<RouterProps, {}> {
 
 const ScrollToTopWithRouter = withRouter(ScrollToTop);
 
-const Work = () => {
+const Work = (props: RouterProps) => {
   const { bannerState, bannerDispatch } = React.useContext(BannerContext);
   let close = () => bannerDispatch({type: 'close'});
 
@@ -72,7 +72,7 @@ const Work = () => {
             <Route exact path="/listings/:id" component={Listing} />
             <Route exact path="/login" component={Login} />
             <Route exact path="/logout" component={Logout} />
-            <Route exact path="/search" component={Search} />
+            <Route exact path="/search" render={() => <Search key={props.location.key} />} />
             <Route exact path="/signup" component={Signup} />
             <AuthenticatedRoute exact path="/trips/:id/receipt" component={TripsReceipt} />
             <AuthenticatedRoute path="/trips" component={Trips} />
@@ -87,4 +87,4 @@ const Work = () => {
   );
 };
 
-export default Work;
+export default withRouter(Work);


### PR DESCRIPTION
## Description
Why did you write this code?
search error page would not redirect by url params change when directing to the same base url, ex.
```
/search
```
to
```
/search?locationQuery=San%20Francisco%2C%20CA%2C%20USA
```

would not reload the page because we're effectively on the same route.
 
## How to Test
- [ ] On the home page, click search without any parameters
- [ ] Enter a city from the error page, it should take you to the correct city
- [ ] Test search/listing page normally

Which devices did you test on?
- [x] Chrome on Mac
- [ ] Chrome on PC
- [ ] Firefox on Mac
- [ ] Firefox on PC
- [ ] Safari iPhone
- [ ] Chrome Android

## REVIEWERS:
Check against these principles:

### High level
Does this code need to be written?
What are the alternatives?
Will this implementation become a support issue?
How much error margin does this solution have?

### Code
* Does the code follow industry standards?
JS: https://github.com/airbnb/javascript
React: https://github.com/airbnb/javascript/tree/master/react
https://github.com/vasanthk/react-bits
Documentation headers: http://usejsdoc.org/index.html

* Is there duplicated code? Can it be refactored into a shared method?
* Is the code consistent with our project?
* Are there unit tests? Do they test the states?
* Is the person refactoring another developer's code? If possible, did the original developer approve?

### Variables/Naming:
* Would the variable type led to future edge cases?
* Are the variable naming clear? Would the value contain something other than what the name describes.

### Security
* Can this be hacked or abused by the user?

## Further Work
Will this have future work?

## Learnings
Did you learn anything here you want to share with the team?

